### PR TITLE
docs: update Telegram and Discord social links

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,11 @@ fn test_expensive_function() {
 ## 🤝 Community & Maintainers
 
 Join the discussion and get support:
-* **Community Link**: [Stellar Developer Discord](https://discord.gg/stellardev)
+* **Community Link**: [Stellar Developer Discord](https://discord.gg/5aprtMSyR)
 
 | Maintainer | Role | Telegram |
 |------------|------|----------|
-| Tollcraft Team | Core Developers | [@tollcraft](https://t.me/tollcraft) |
+| Tollcraft Team | Core Developers | [@tollcraft](https://t.me/+Gflo5jZStw1jMjE0) |
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ Currently, only the `main` branch is supported for security updates.
 ## Reporting a Vulnerability
 We take the security of `soroban-budget-assert` seriously. 
 If you discover a security vulnerability, please do NOT report it by creating a public GitHub issue.
-Instead, please send an email to the maintainer or reach out via Telegram at `@tollcraft`.
+Instead, please send an email to the maintainer or reach out via Telegram at `https://t.me/+Gflo5jZStw1jMjE0`.
 
 ## Audit Status
 **DISCLAIMER**: This project is an MVP developer tool and is **UNAUDITED**. 


### PR DESCRIPTION
replace placeholder with active social links for discord and telegram support 