### PR TITLE
fix: history recording failure on main (dirty tree + polluted --json output)

### DIFF
--- a/.github/workflows/budget.yml
+++ b/.github/workflows/budget.yml
@@ -73,9 +73,16 @@ jobs:
         
         # Save report to temp location so it survives the checkout
         cp current_report.json /tmp/current_report.json
-        
-        # Fetch and checkout the gh-pages branch, or create it if missing
-        git checkout gh-pages || git checkout -b gh-pages
+
+        # Discard build/test artifacts: cargo test rewrites the committed
+        # test_snapshots, and a dirty tree makes the checkout below abort
+        git reset --hard HEAD
+        git clean -fd
+
+        # Checkout the existing gh-pages branch. Never fall back to branching
+        # off main — that would replace the published site; use an orphan
+        # branch if gh-pages doesn't exist yet.
+        git checkout gh-pages || { git checkout --orphan gh-pages && git rm -rfq . ; }
         
         # Initialize history.json if it doesn't exist
         if [ ! -f history.json ]; then

--- a/cargo-budget-report/src/main.rs
+++ b/cargo-budget-report/src/main.rs
@@ -93,7 +93,7 @@ fn main() -> Result<()> {
         .or(toml_config.source)
         .context("missing --source or budget.toml source field")?;
 
-    println!("Discovering workspace members...");
+    eprintln!("Discovering workspace members...");
     let metadata = MetadataCommand::new()
         .no_deps()
         .exec()
@@ -110,7 +110,7 @@ fn main() -> Result<()> {
             continue;
         }
 
-        println!("Building package '{}' for wasm32...", package.name);
+        eprintln!("Building package '{}' for wasm32...", package.name);
         let build_status = Command::new("cargo")
             .args([
                 "build",
@@ -136,7 +136,7 @@ fn main() -> Result<()> {
             .join(format!("{}.wasm", wasm_name));
 
         if !wasm_path.exists() {
-            println!("Warning: WASM not found at {}", wasm_path);
+            eprintln!("Warning: WASM not found at {}", wasm_path);
             continue;
         }
 
@@ -160,7 +160,7 @@ fn main() -> Result<()> {
         }
 
         if exported_fns.is_empty() {
-            println!("No exported functions found in {}", package.name);
+            eprintln!("No exported functions found in {}", package.name);
             continue;
         }
 
@@ -201,10 +201,10 @@ fn main() -> Result<()> {
         let contract_id = String::from_utf8_lossy(&deploy_output.stdout)
             .trim()
             .to_string();
-        println!("Contract deployed at: {}", contract_id);
+        eprintln!("Contract deployed at: {}", contract_id);
 
         for function in exported_fns {
-            println!("Simulating function '{}'...", function);
+            eprintln!("Simulating function '{}'...", function);
 
             let func_config = toml_config.functions.get(&function);
             let func_args = func_config.map(|c| c.args.clone()).unwrap_or_default();
@@ -230,7 +230,7 @@ fn main() -> Result<()> {
                 .context("failed to execute stellar-cli invoke")?;
 
             if !invoke_output.status.success() {
-                println!(
+                eprintln!(
                     "Warning: Simulation failed for {}: {}",
                     function,
                     String::from_utf8_lossy(&invoke_output.stderr)
@@ -282,7 +282,7 @@ fn main() -> Result<()> {
                 .context("Failed to parse RPC response")?;
 
             if let Some(error) = rpc_resp.get("error") {
-                println!("Warning: RPC error for {}: {}", function, error);
+                eprintln!("Warning: RPC error for {}: {}", function, error);
                 continue;
             }
 
@@ -337,17 +337,16 @@ fn main() -> Result<()> {
     }
 
     if reports.is_empty() {
-        println!("No successful simulations to report.");
+        eprintln!("No successful simulations to report.");
         return Ok(());
     }
-
-    println!("\n=== WORKSPACE BUDGET REPORT ===");
 
     if args.json {
         let json_output =
             serde_json::to_string_pretty(&reports).context("Failed to serialize report to JSON")?;
         println!("{}", json_output);
     } else {
+        println!("\n=== WORKSPACE BUDGET REPORT ===");
         let table_reports: Vec<TableCostReport> = reports
             .into_iter()
             .map(|r| {


### PR DESCRIPTION
## Summary
The first real post-merge run of `Record History Dataset` on `main` failed (run after #24). Two root causes, both fixed:

1. **CLI**: `cargo budget-report --json` printed progress lines ("Discovering workspace members...", "Contract deployed at: ...") to stdout, so `current_report.json` wasn't valid JSON and `jq --slurpfile` failed. All progress/warning output now goes to stderr; stdout carries only the report (JSON or table). The `=== WORKSPACE BUDGET REPORT ===` header moved into the table branch for the same reason.
2. **Workflow**: `cargo test` rewrites the committed `amm-pool-contract/test_snapshots/*.json`, so `git checkout gh-pages` aborted on a dirty tree — and the `|| git checkout -b gh-pages` fallback silently created a new branch off `main`, which would have replaced the published site had the job continued. The step now does `git reset --hard && git clean -fd` after saving the report, and the fallback is an orphan branch instead of a fork of `main`.

## Test plan
- [x] Real end-to-end run against testnet: `cargo run --bin cargo-budget-report -- budget-report --json` produces jq-parseable stdout (verified with the exact `jq --slurpfile` invocation the workflow uses); progress appears on stderr
- [x] `cargo fmt` / `clippy -D warnings` / `cargo test --workspace` (6/6) all pass
- [ ] After merge: `Record History Dataset` step succeeds on the `main` push and `history.json` on `gh-pages` gains an entry