### PR TITLE
chore: update actions/checkout to v4 in budget workflow

### DIFF
--- a/.github/workflows/budget.yml
+++ b/.github/workflows/budget.yml
@@ -14,7 +14,7 @@ jobs:
       contents: write
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
 


### PR DESCRIPTION
Update `actions/checkout` from `v3` to `v4` in the budget CI workflow.

`actions/checkout@v3` runs on a Node.js runtime that GitHub has deprecated, producing a deprecation warning on every push and PR to main. v4 uses a current Node.js runtime and eliminates the warning.

All existing inputs (including `fetch-depth: 0`) are preserved. The `Record History Dataset` step relies on a full-depth fetch for its git operations, which `fetch-depth: 0` provides.

Closes #96