### PR TITLE
refactor: extract shared WASM-contract test setup helper in budget_test.rs

### DIFF
--- a/amm-pool-contract/tests/budget_test.rs
+++ b/amm-pool-contract/tests/budget_test.rs
@@ -4,6 +4,16 @@ use amm_pool_contract::{ExpensiveContract, ExpensiveContractClient};
 use budget_macros::budget_cpu_lt;
 use soroban_sdk::Env;
 
+fn setup_wasm_client(env: &Env) -> ExpensiveContractClient {
+    let wasm_path = "../target/wasm32-unknown-unknown/release/amm_pool_contract.wasm";
+    let wasm = std::fs::read(wasm_path).expect("WASM file not found, did you run cargo build?");
+    #[allow(deprecated)]
+    let contract_id = env.register_contract_wasm(None, wasm.as_slice());
+    let client = ExpensiveContractClient::new(env, &contract_id);
+    env.cost_estimate().budget().reset_unlimited();
+    client
+}
+
 #[test]
 fn test_budget_raw_rust() {
     let env = Env::default();
@@ -24,15 +34,7 @@ fn test_budget_raw_rust() {
 #[test]
 fn test_budget_wasm() {
     let env = Env::default();
-
-    // Path to the compiled wasm
-    let wasm_path = "../target/wasm32-unknown-unknown/release/amm_pool_contract.wasm";
-    let wasm = std::fs::read(wasm_path).expect("WASM file not found, did you run cargo build?");
-    #[allow(deprecated)]
-    let contract_id = env.register_contract_wasm(None, wasm.as_slice());
-    let client = ExpensiveContractClient::new(&env, &contract_id);
-
-    env.cost_estimate().budget().reset_unlimited();
+    let client = setup_wasm_client(&env);
 
     client.do_expensive_work(&10_000);
 
@@ -46,15 +48,7 @@ fn test_budget_wasm() {
 #[budget_cpu_lt(950000)] // Re-measured with the Soroban release profile applied: WASM local 901816, actual testnet ~756678
 fn test_budget_macro_gated() {
     let env = Env::default();
-
-    // Path to the compiled wasm
-    let wasm_path = "../target/wasm32-unknown-unknown/release/amm_pool_contract.wasm";
-    let wasm = std::fs::read(wasm_path).expect("WASM file not found, did you run cargo build?");
-    #[allow(deprecated)]
-    let contract_id = env.register_contract_wasm(None, wasm.as_slice());
-    let client = ExpensiveContractClient::new(&env, &contract_id);
-
-    env.cost_estimate().budget().reset_unlimited();
+    let client = setup_wasm_client(&env);
 
     client.do_expensive_work(&10_000); // Should pass as it's < 850000 CPU limit
 }
@@ -64,15 +58,7 @@ fn test_budget_macro_gated() {
 #[budget_cpu_lt(600000)] // Deliberate regression
 fn test_budget_macro_deliberate_regression() {
     let env = Env::default();
-
-    // Path to the compiled wasm
-    let wasm_path = "../target/wasm32-unknown-unknown/release/amm_pool_contract.wasm";
-    let wasm = std::fs::read(wasm_path).expect("WASM file not found, did you run cargo build?");
-    #[allow(deprecated)]
-    let contract_id = env.register_contract_wasm(None, wasm.as_slice());
-    let client = ExpensiveContractClient::new(&env, &contract_id);
-
-    env.cost_estimate().budget().reset_unlimited();
+    let client = setup_wasm_client(&env);
 
     client.do_expensive_work(&10_000);
 }
@@ -82,14 +68,7 @@ fn test_budget_macro_deliberate_regression() {
 fn test_budget_macro_dynamic_env() {
     std::env::set_var("TEST_MAX_CPU", "950000");
     let env = Env::default();
-
-    let wasm_path = "../target/wasm32-unknown-unknown/release/amm_pool_contract.wasm";
-    let wasm = std::fs::read(wasm_path).expect("WASM file not found, did you run cargo build?");
-    #[allow(deprecated)]
-    let contract_id = env.register_contract_wasm(None, wasm.as_slice());
-    let client = ExpensiveContractClient::new(&env, &contract_id);
-
-    env.cost_estimate().budget().reset_unlimited();
+    let client = setup_wasm_client(&env);
 
     client.do_expensive_work(&10_000);
 }
@@ -99,14 +78,7 @@ fn test_budget_macro_dynamic_env() {
 fn test_budget_macro_dynamic_env_fallback() {
     std::env::remove_var("TEST_MAX_CPU_FALLBACK");
     let env = Env::default();
-
-    let wasm_path = "../target/wasm32-unknown-unknown/release/amm_pool_contract.wasm";
-    let wasm = std::fs::read(wasm_path).expect("WASM file not found, did you run cargo build?");
-    #[allow(deprecated)]
-    let contract_id = env.register_contract_wasm(None, wasm.as_slice());
-    let client = ExpensiveContractClient::new(&env, &contract_id);
-
-    env.cost_estimate().budget().reset_unlimited();
+    let client = setup_wasm_client(&env);
 
     client.do_expensive_work(&10_000);
 }


### PR DESCRIPTION
Extract the duplicated WASM-contract setup block (read wasm path, read bytes, register contract, build client, reset budget) into a shared `setup_wasm_client` helper function.

Updated all four affected tests (`test_budget_wasm`, `test_budget_macro_gated`, `test_budget_macro_dynamic_env`, `test_budget_macro_dynamic_env_fallback`) plus `test_budget_macro_deliberate_regression` which had the same duplication. `test_budget_raw_rust` is left unchanged since it doesn't use the WASM path.

Closes #94