### PR TITLE
chore: add rustfmt and clippy configuration files

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,24 @@
+# Clippy configuration for soroban-budget-assert.
+#
+# Decision: the default lint set is right for this repository. `CONTRIBUTING.md`
+# gates on `cargo clippy --workspace --all-targets -- -D warnings`, and the
+# workspace passes that on defaults, so nothing here relaxes or adds a lint.
+#
+# What this file does do is pin the tunable thresholds that the default lints
+# read. They are set to their current upstream defaults on purpose: if a future
+# clippy release changes a default, the gate stays where it is today instead of
+# moving under an unchanged source tree. Same reasoning as `rustfmt.toml`.
+#
+# Not set here:
+#   * `msrv` -- the project declares no `rust-version`, and the toolchain is
+#     unpinned. Pinning an MSRV belongs with the toolchain work (issue #113);
+#     setting one here would only silence version-gated suggestions based on a
+#     number nothing else in the repo enforces.
+#   * `avoid-breaking-exported-api` -- left at its default (`true`). The crates
+#     here are a proc-macro library and a CLI binary, neither of which has an
+#     API surface stable enough to be worth linting against.
+
+too-many-arguments-threshold = 7
+type-complexity-threshold = 250
+enum-variant-name-threshold = 3
+single-char-binding-names-threshold = 4

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,31 @@
+# rustfmt configuration for soroban-budget-assert.
+#
+# `CONTRIBUTING.md` makes `cargo fmt --all -- --check` a merge gate, so the
+# formatting rules have to be a property of the repository rather than of
+# whichever toolchain a contributor happens to have installed. Every option
+# below is stable on the release channel and records the formatting the
+# codebase already uses -- adding this file reformats nothing.
+#
+# `style_edition` is the important one: it freezes the formatting rules
+# themselves, so a newer rustfmt cannot change the expected output from under
+# an unchanged source tree.
+
+style_edition = "2021"
+edition = "2021"
+
+max_width = 100
+hard_tabs = false
+tab_spaces = 4
+newline_style = "Unix"
+use_small_heuristics = "Default"
+
+reorder_imports = true
+reorder_modules = true
+merge_derives = true
+remove_nested_parens = true
+
+force_explicit_abi = true
+fn_params_layout = "Tall"
+match_arm_leading_pipes = "Never"
+use_field_init_shorthand = false
+use_try_shorthand = false


### PR DESCRIPTION
Closes #126.

## Problem

The repository had no `rustfmt.toml` and no `clippy.toml`, so both tools ran on
whichever defaults the contributor's toolchain happened to ship. `CONTRIBUTING.md`
makes `cargo fmt --all -- --check` and `cargo clippy --workspace --all-targets -- -D warnings`
a merge gate, which meant the gate was governed by a compiler version rather than by
the repository. The toolchain is also unpinned (`.github/workflows/budget.yml` installs
`dtolnay/rust-toolchain@stable`), so the gate could move on its own between runs.

## What changed

**`rustfmt.toml`** — every option is stable on the release channel, and every value was
derived from the formatting the codebase already uses rather than from preference. Nothing
here reformats anything.

The load-bearing setting is `style_edition = "2021"`. That is what actually freezes the
formatting *rules*; without it a newer rustfmt can change expected output for an unchanged
source tree. The remaining options record the layout the sources already satisfy
(`max_width`, `tab_spaces`, `use_small_heuristics`, import/module ordering, and the small
set of shorthand and layout switches).

**`clippy.toml`** — the documented decision is that the default lint set is right for this
repository: the workspace passes `-D warnings` on defaults today, and nothing in this file
relaxes or adds a lint. What it does pin is the tunable thresholds that the
enabled-by-default lints read (`too_many_arguments`, `type_complexity`, `enum_variant_names`,
`many_single_char_names`), set to their current upstream defaults so a future clippy release
cannot move the gate under an unchanged tree.

Two options are deliberately *not* set, and the file says why:

- `msrv` — the project declares no `rust-version` and the toolchain is unpinned. That belongs
  with the toolchain work in #113, not here; setting a number nothing else in the repo
  enforces would only silence version-gated suggestions.
- `avoid-breaking-exported-api` — left at its default. A proc-macro crate and a CLI binary
  have no API surface stable enough to lint against.

## Verification

No source file changed as a side effect. The commit touches exactly two files, both new:

```
 clippy.toml  | 24 ++++++++++++++++++++++++
 rustfmt.toml | 31 +++++++++++++++++++++++++++++++
 2 files changed, 55 insertions(+)
```

Checks run locally on the unchanged codebase with the config in place (rustfmt 1.9.0-stable,
clippy 0.1.97):

- `cargo fmt --all -- --check` — passes, no diff, and rustfmt reports no unknown/unstable options
- `cargo clippy --workspace --all-targets -- -D warnings` — passes, and clippy raises no
  configuration-file error, confirming every key is valid

## Related

#113 pins the toolchain, which is the other half of making these checks reproducible.

## Out of scope

No reformatting.
