### PR TITLE
docs: fix README and documentation macro examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,14 +57,35 @@ cargo budget-report
 ```
 
 **Use Macros in Tests:**
-```rust
-use budget_macros::budget_cpu_lt;
 
+The macros (`budget_cpu_lt`, `budget_mem_lt`) are attribute macros for test functions. They require a local variable named **`env`** — the generated code reads `env.cost_estimate().budget()` by name.
+
+```rust
+use budget_macros::{budget_cpu_lt, budget_mem_lt};
+use soroban_sdk::Env;
+
+// CPU instruction assertion
 #[test]
-#[budget_cpu_lt(800000)]
-fn test_expensive_function() {
+#[budget_cpu_lt(950000)] // local WASM ~901,816; testnet ~756,678
+fn test_cpu_budget() {
     let env = Env::default();
-    // ... test logic ...
+
+    let wasm = std::fs::read(
+        "../target/wasm32-unknown-unknown/release/my_contract.wasm",
+    ).expect("build the WASM first");
+    let contract_id = env.register_contract_wasm(None, wasm.as_slice());
+    let client = MyContractClient::new(&env, &contract_id);
+
+    env.cost_estimate().budget().reset_unlimited();
+    client.do_expensive_work(&10_000);
+}
+
+// Memory assertion — same shape
+#[test]
+#[budget_mem_lt(500000)]
+fn test_mem_budget() {
+    let env = Env::default();
+    // register, reset_unlimited, invoke …
 }
 ```
 

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -14,18 +14,47 @@ Asserts that the CPU instruction cost measured by the test's `env` is strictly l
 
 ```rust
 use budget_macros::budget_cpu_lt;
+use soroban_sdk::Env;
 
 #[test]
-#[budget_cpu_lt(850000)]
+#[budget_cpu_lt(950000)] // local WASM ~901,816; testnet ~756,678
 fn test_expensive_function() {
     let env = Env::default();
-    // ... register contract as WASM, call client ...
+
+    let wasm = std::fs::read(
+        "../target/wasm32-unknown-unknown/release/my_contract.wasm",
+    ).expect("build the WASM first");
+    let contract_id = env.register_contract_wasm(None, wasm.as_slice());
+    let client = MyContractClient::new(&env, &contract_id);
+
+    env.cost_estimate().budget().reset_unlimited();
+    client.do_expensive_work(&10_000);
 }
 ```
 
 ### `#[budget_mem_lt(N)]`
 
 Same shape; asserts `memory_bytes_cost() < N`.
+
+```rust
+use budget_macros::budget_mem_lt;
+use soroban_sdk::Env;
+
+#[test]
+#[budget_mem_lt(500000)]
+fn test_memory_budget() {
+    let env = Env::default();
+
+    let wasm = std::fs::read(
+        "../target/wasm32-unknown-unknown/release/my_contract.wasm",
+    ).expect("build the WASM first");
+    let contract_id = env.register_contract_wasm(None, wasm.as_slice());
+    let client = MyContractClient::new(&env, &contract_id);
+
+    env.cost_estimate().budget().reset_unlimited();
+    client.do_expensive_work(&10_000);
+}
+```
 
 ### Requirements and caveats
 


### PR DESCRIPTION
## Summary

The quick-start example in `README.md` (lines 60-69) and the macro usage examples in `docs/src/reference.md` (lines 15-24) were incomplete and would not compile or pass as written. A reader copying the example into their own project would find that:

1. The asserted budget limit measures nothing meaningful because `reset_unlimited()` is never called.
2. No contract is registered or invoked, so a reader cannot tell that the macro asserts against work done through `env`.
3. The requirement that the local `Env` binding must be named `env` is implicit -- the generated code in `budget-macros/src/lib.rs:51` hard-codes the identifier `env`.
4. `budget_mem_lt` was absent from the README's usage section even though the architecture section above advertises it.

This PR fixes all four issues across both the top-level `README.md` and the documentation site source at `docs/src/reference.md`.

## Changes

### `README.md`

**Before** -- lines 60-69:
```rust
use budget_macros::budget_cpu_lt;

#[test]
#[budget_cpu_lt(800000)]
fn test_expensive_function() {
    let env = Env::default();
    // ... test logic ...
}
```

**After**:
- Documents that the variable **must** be named `env`, with an explanation that the macro resolves it by name.
- First example (`test_cpu_budget`) is a complete, working test: reads compiled WASM, registers it, creates a client, calls `reset_unlimited()`, and invokes a contract function.
- Second example (`test_mem_budget`) shows `#[budget_mem_lt(500000)]` with the same shape.
- Both examples include an inline comment noting the measured local vs. network cost, following the convention from `user_guide.md`.

### `docs/src/reference.md`

**Before** -- `budget_cpu_lt` example:
```rust
#[budget_cpu_lt(850000)]
fn test_expensive_function() {
    let env = Env::default();
    // ... register contract as WASM, call client ...
}
```

**Before** -- `budget_mem_lt` had no code example at all.

**After**:
- `budget_cpu_lt` example now shows the full test body with `reset_unlimited()`, WASM registration, and invocation.
- `budget_mem_lt` now has its own complete code example (previously just said "Same shape; asserts `memory_bytes_cost() < N`").
- Both examples include the `use soroban_sdk::Env;` import that was missing.

## Verification

All examples are adapted from the working integration tests in `amm-pool-contract/tests/budget_test.rs`:

- `test_budget_macro_gated` (line 46) -- the passing CPU assertion pattern.
- `test_budget_wasm` (line 25) -- the WASM registration and `reset_unlimited()` pattern.

The `env` identifier requirement is documented as it exists today, referencing the generated code at `budget-macros/src/lib.rs:51` where the macro constructs `proc_macro2::Ident::new("env", ...)`. Issue #11 proposes making this configurable -- the documentation describes current behavior only.

## Out of scope

- No changes to the macro implementation itself.
- `docs/src/user_guide.md` already had a correct, complete example and was not modified.

Closes #103