### PR TITLE
docs: document what this tool does not measure

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ## 📖 Overview
 
-`soroban-budget-assert` is a developer tool that measures the gap between local Soroban test estimates and real network costs. It allows developers to assert budget limits during testing and automatically generate detailed cost reports across an entire workspace.
+`soroban-budget-assert` is a developer tool that measures the gap between local Soroban test estimates and real network costs. It allows developers to assert budget limits during testing and automatically generate detailed execution-resource reports across an entire workspace.
 
 ### 🏗️ Architecture
 
@@ -26,7 +26,8 @@ The tool is split into two primary components:
 
 2. **`cargo-budget-report` (Tier B - Network-Verified, Reporting)**
    - A CLI tool that automatically discovers all contracts in your workspace.
-   - Compiles WASM, simulates execution on testnet, and reports actual non-refundable costs (CPU instructions, read/write bytes).
+   - Compiles WASM, simulates execution on testnet, and reports the simulated resource amounts (CPU instructions, read/write bytes).
+   - These are inputs to the non-refundable resource fee — not a total cost. Rent, refundable fees, transaction size, footprint entry counts, and the inclusion fee are not measured; see [Measurement scope](https://tollcraft.gitbook.io/docs/budget-assert/reference#measurement-scope).
    - Configurable via a central `budget.toml` file.
 
 ---

--- a/cargo-budget-report/src/main.rs
+++ b/cargo-budget-report/src/main.rs
@@ -361,8 +361,10 @@ fn main() -> Result<()> {
             .collect();
         let table = Table::new(table_reports).to_string();
         println!("{}", table);
-        println!("\nSummary: The metrics above represent the total unrefundable network execution costs required to run your contract functions.");
+        println!("\nSummary: The values above are simulated resource amounts, not fees. They are three of the inputs to the non-refundable resource fee.");
+        println!("* Not measured: transaction size, ledger footprint entry counts, refundable fees (rent, events, return value), the inclusion fee, and therefore the total fee charged.");
         println!("* Note: These are simulated numbers on testnet and may vary slightly depending on ledger state.");
+        println!("* See the \"Measurement scope\" section of the Tool Reference for what to use instead when you need those figures.");
     }
 
     Ok(())

--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -11,4 +11,8 @@ Measured on this repo's example contract (`do_expensive_work(10_000)`, testnet g
 A developer who trusts local numbers either deploys a contract that exhausts its budget on the public network, or over-provisions against costs that aren't real. Both mistakes come from the same root cause: the only trustworthy number is a network simulation of the exact WASM you deploy.
 {% endhint %}
 
-This tool provides both halves of the fix: `cargo budget-report` measures real simulated network costs across a whole workspace, and the `budget_macros` assertions pin measured costs into `cargo test` so a cost regression fails CI before it fails on-chain.
+This tool provides both halves of the fix: `cargo budget-report` measures network-simulated resource usage across a whole workspace, and the `budget_macros` assertions pin measured costs into `cargo test` so a cost regression fails CI before it fails on-chain.
+
+{% hint style="info" %}
+Scope: the report covers execution resources — CPU instructions and ledger read/write bytes. Those are inputs to the non-refundable resource fee, not a total transaction fee: rent, refundable fees, transaction size, footprint entry counts, and the inclusion fee are not measured. [Measurement scope](reference.md#measurement-scope) sets out the boundary and points at where to find the rest.
+{% endhint %}

--- a/docs/src/mechanics.md
+++ b/docs/src/mechanics.md
@@ -45,7 +45,9 @@ The CLI measures ground truth. One invocation walks this pipeline:
 6. **Decode** — decodes the returned `SorobanTransactionData` XDR (`stellar xdr decode`) and extracts `resources.instructions`, `resources.disk_read_bytes`, and `resources.write_bytes`.
 7. **Report** — aggregates every package/function pair into one table, or JSON with `--json`.
 
-Simulated numbers vary slightly with ledger state, but they are the numbers the network will charge — non-refundable resource costs, not local approximations.
+Simulated numbers vary slightly with ledger state, but they are the network's own measurement of the exact WASM you deploy, not a local approximation.
+
+These three figures are resource *amounts*, and they are inputs to the non-refundable resource fee — not the fee itself and not a total cost. Rent, other refundable fees, transaction size, footprint entry counts, and the inclusion fee are outside what the tool measures. See [Measurement scope](reference.md#measurement-scope) for the full boundary and where to find the omitted pieces.
 
 ## How the tiers work together
 

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -74,7 +74,9 @@ args = ["--n", "10000"]
 
 Each simulated function produces three rows (or three JSON objects): `CPU Instructions`, `Read Bytes`, and `Write Bytes`.
 
-Table output ends with a note that values are testnet simulations and vary slightly with ledger state. JSON output (`--json`) is an array suited to CI:
+Table output ends with a note that the values are simulated resource amounts rather than fees,
+what is not measured, and that testnet simulations vary slightly with ledger state — see
+[Measurement scope](#measurement-scope). JSON output (`--json`) is an array suited to CI:
 
 ```json
 [
@@ -86,6 +88,66 @@ Table output ends with a note that values are testnet simulations and vary sligh
   }
 ]
 ```
+
+## Measurement scope
+
+`cargo budget-report` reports **resource amounts from a simulation, not fees**. It reads three
+fields out of the `SorobanTransactionData` returned by `simulateTransaction` —
+`resources.instructions`, `resources.disk_read_bytes`, and `resources.write_bytes` — and prints
+them unchanged. Nothing in the output is denominated in stroops, and no figure it prints is a
+total.
+
+### In scope
+
+| Reported | Stellar resource it corresponds to |
+|---|---|
+| `CPU Instructions` | `resources.instructions` — metered CPU instruction count |
+| `Read Bytes` | `resources.disk_read_bytes` — bytes read from disk-backed ledger entries |
+| `Write Bytes` | `resources.write_bytes` — bytes written to ledger entries |
+
+These three quantities are *inputs* to the **non-refundable resource fee**. They are not the
+whole of it.
+
+### Not in scope
+
+{% hint style="warning" %}
+Do not treat the reported numbers as what a transaction will cost. On Stellar, the total
+transaction fee is `resource fee + inclusion fee`, and the resource fee is itself
+`non-refundable + refundable`. This tool measures neither total, and does not convert what it
+measures into a fee.
+{% endhint %}
+
+- **Rent** — the fee for creating ledger entries and extending their TTL. Rent is a *refundable*
+  resource fee, charged up front and refunded against actual usage. It is frequently the largest
+  single line item for a contract that writes persistent state, and it is entirely absent here.
+  A simulation surfaces it in the `minResourceFee` and the returned `SorobanTransactionData`
+  rent-change data; the [Fees, resource limits, and metering][fees] page explains how it is
+  computed.
+- **Other refundable fees** — the size of emitted events and of the return value are also
+  charged as refundable resource fees. Not measured.
+- **Transaction size (bandwidth)** — the serialized transaction and its signatures are charged
+  as part of the *non-refundable* resource fee. So even within the non-refundable portion, the
+  three reported figures are incomplete.
+- **Ledger footprint** — the read-only and read-write entry *keys and counts* in the footprint
+  are charged per entry, separately from the byte counts reported here. A function that touches
+  many small entries can cost far more than its byte totals suggest. `stellar contract invoke
+  --build-only` followed by `stellar xdr decode --type SorobanTransactionData` shows the full
+  footprint for a transaction the tool has already built.
+- **Total transaction fee** — requires the inclusion fee, which is a bid set by the submitter
+  and not a property of the contract at all. The `minResourceFee` field of a
+  `simulateTransaction` response is the closest single number to "what the resources cost";
+  reach for that, not for this report, when you need a figure in stroops.
+- **WASM binary size** — the size of the deployed contract binary is not reported. This is
+  coming: see issue #88.
+
+### What the report is good for
+
+Comparing a function against itself over time. The three metrics are the ones that move when
+contract logic changes, so they are the right signal for catching an execution-cost regression
+— which is exactly what the Tier A macros pin into `cargo test`. They are the wrong signal for
+answering "how much will my users pay".
+
+[fees]: https://developers.stellar.org/docs/learn/fundamentals/fees-resource-limits-metering
 
 ## Failure behavior
 

--- a/docs/src/user_guide.md
+++ b/docs/src/user_guide.md
@@ -30,13 +30,17 @@ args = ["--n", "10000"]
 ```
 {% endcode %}
 
-## Step 3: Measure real costs
+## Step 3: Measure network resource usage
 
 ```bash
 cargo budget-report
 ```
 
 The CLI finds every contract in the workspace, builds it to WASM, deploys to testnet, simulates every exported function, and prints one table of CPU instructions, read bytes, and write bytes. Use `--json` if you want to feed the numbers to a script.
+
+{% hint style="warning" %}
+This is not your transaction fee. The three metrics are inputs to the non-refundable resource fee; rent, refundable fees, transaction size, footprint entry counts, and the inclusion fee are not measured. If you are budgeting what users will actually pay — especially for a contract that writes persistent state, where rent often dominates — read [Measurement scope](reference.md#measurement-scope) first.
+{% endhint %}
 
 ## Step 4: Pin the costs into tests
 


### PR DESCRIPTION
Closes #133.

## Problem

Every table report closed with:

> Summary: The metrics above represent the total unrefundable network execution costs required to run your contract functions.

That is broader than what the tool measures, in two separate ways. The three figures are
resource *amounts* read straight out of a `simulateTransaction` response
(`resources.instructions`, `resources.disk_read_bytes`, `resources.write_bytes`) — they are not
fees and are never converted into any. And even read as fee inputs, they are three of several
inputs to the non-refundable resource fee, not the whole of it.

A developer taking the line at face value budgets against a number that omits components they
are actually charged for. For a contract that writes persistent state, rent alone can dominate
what this report shows.

## Verifying the split

Checked against Stellar's [Fees, resource limits, and metering][fees] page before writing the
boundary, since the refundable/non-refundable split is easy to get backwards:

- **Total transaction fee** = resource fee + inclusion fee
- **Resource fee** = non-refundable + refundable
- **Non-refundable**: CPU instructions, read bytes, write bytes, **and bandwidth (transaction
  size and signatures)**
- **Refundable**: **rent** (TTL extensions), events size, return value size — charged up front
  and refunded against actual usage

Two consequences the docs now state explicitly: rent is *refundable*, not part of the
non-refundable fee the old line gestured at; and transaction size is non-refundable, so the
three reported figures do not even cover the whole non-refundable portion.

## Changes

**Tool output** (`cargo-budget-report/src/main.rs`) — the summary line now says the values are
simulated resource amounts rather than fees, names what is not measured, and points at the docs
section for the omitted figures.

**`docs/src/reference.md`** — new **Measurement scope** section: a table mapping each reported
column to its underlying Stellar resource, then what is out of scope, each with a pointer to
where the figure can actually be found:

| Omitted | Where to look instead |
|---|---|
| Rent | `minResourceFee` and the rent-change data in the simulated `SorobanTransactionData` |
| Events / return value size | refundable resource fees, per the fee docs |
| Transaction size (bandwidth) | non-refundable, but not among the reported fields |
| Ledger footprint entry counts | `stellar xdr decode --type SorobanTransactionData` on the built tx |
| Total transaction fee | needs the inclusion fee, which is a submitter bid; `minResourceFee` is the closest single stroop figure |
| WASM binary size | **coming — #88** |

It closes by saying what the report *is* good for: comparing a function against itself over
time, which is the signal the Tier A macros pin into `cargo test`.

**Aligned the same claim everywhere else it appeared**, so the tool and the docs now agree:

- `README.md` — "reports actual non-refundable costs" → simulated resource amounts, plus the
  scope boundary and a link
- `docs/src/README.md` — scope hint under the introduction
- `docs/src/mechanics.md` — Tier B no longer says the numbers "are the numbers the network will
  charge"; it says they are the network's own measurement of the WASM you deploy, and links the
  boundary
- `docs/src/user_guide.md` — Step 3 retitled from "Measure real costs" to "Measure network
  resource usage", with a warning that calls out rent for state-writing contracts
- `docs/src/reference.md` — the Output section's description of the trailing note updated to match

## Verification

```
cargo fmt --all -- --check                                    # passes
cargo clippy --workspace --all-targets -- -D warnings         # passes
cargo test --workspace                                        # 6 passed, 0 failed
```

No behavior change — output text and documentation only. Test snapshots regenerated by the local
run were deliberately kept out of the commit.

## Out of scope

None of the omitted components are measured here; they are documented and pointed at, not
implemented.

[fees]: https://developers.stellar.org/docs/learn/fundamentals/fees-resource-limits-metering
