### PR TITLE
chore: add current_report.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ req.json
 node_modules/
 docs/book/
 *.pdf
+current_report.json


### PR DESCRIPTION
## Summary

Adds `current_report.json` to `.gitignore`. This file is written by the `Run Budget Report (Tier B)` workflow step and lands in the working tree of anyone running the reporting command locally. Without an ignore entry, it shows up in `git status` as an untracked file.

## Artifact identification

The only report artifact produced is `current_report.json`, written at `.github/workflows/budget.yml:46`. The `cargo-budget-report` CLI prints JSON to stdout (via `println!`) and does not write any file itself; the redirection to `current_report.json` is done exclusively by the workflow shell.

## Git clean analysis

With `current_report.json` now ignored, the `git clean -fd` in the `Record History Dataset` step no longer removes it (because `git clean -fd` without `-x` skips ignored files). However:

- The `git clean -fd` cannot be removed — it still protects against other untracked non-ignored artifacts (e.g., `contract_id.txt`, `req.json`, build outputs from the test step).
- The `/tmp` copy is still needed because the `jq --slurpfile` reference on line 75 reads from `/tmp/current_report.json`, and the file would not be in the same working-tree location after the branch switch.

No workflow step is made redundant by this change.

Closes #105