### PR TITLE
fixed bug

### DIFF
--- a/cargo-budget-report/src/main.rs
+++ b/cargo-budget-report/src/main.rs
@@ -3,6 +3,7 @@ use cargo_metadata::MetadataCommand;
 use clap::Parser;
 use indicatif::{ProgressBar, ProgressStyle};
 use std::collections::HashMap;
+use std::path::Path;
 use std::process::Command;
 use tabled::{Table, Tabled};
 use wasmparser::Parser as WasmParser;
@@ -76,13 +77,19 @@ fn format_with_commas_and_units(value: u32, metric: &str) -> String {
     }
 }
 
+fn load_budget_toml<P: AsRef<Path>>(path: P) -> Result<BudgetToml> {
+    match std::fs::read_to_string(&path) {
+        Ok(contents) => toml::from_str(&contents)
+            .map_err(|err| anyhow::anyhow!("failed to parse {}: {}", path.as_ref().display(), err)),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(BudgetToml::default()),
+        Err(err) => Err(err).with_context(|| format!("failed to read {}", path.as_ref().display())),
+    }
+}
+
 fn main() -> Result<()> {
     let CargoCli::BudgetReport(args) = CargoCli::parse();
 
-    let toml_config: BudgetToml = std::fs::read_to_string("budget.toml")
-        .ok()
-        .and_then(|s| toml::from_str(&s).ok())
-        .unwrap_or_default();
+    let toml_config = load_budget_toml("budget.toml")?;
 
     let network = args
         .network
@@ -366,4 +373,50 @@ fn main() -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn unique_test_path() -> PathBuf {
+        let mut path = std::env::temp_dir();
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time is before UNIX_EPOCH")
+            .as_nanos();
+        path.push(format!("cargo_budget_report_test_{}.toml", nanos));
+        path
+    }
+
+    #[test]
+    fn missing_budget_toml_returns_default() {
+        let path = unique_test_path();
+        let _ = fs::remove_file(&path);
+
+        let config = load_budget_toml(&path).expect("missing file should return default");
+        assert!(config.network.is_none());
+        assert!(config.source.is_none());
+        assert!(config.functions.is_empty());
+    }
+
+    #[test]
+    fn malformed_budget_toml_errors_with_parse_message() {
+        let path = unique_test_path();
+        fs::write(
+            &path,
+            "network = \"testnet\"\n[functions.do_expensive_work]\nargs = \"--n 10\"\n",
+        )
+        .expect("failed to write malformed budget.toml");
+
+        let err = load_budget_toml(&path).unwrap_err();
+        let err_text = err.to_string();
+
+        assert!(err_text.contains("failed to parse"));
+        assert!(err_text.contains("line") || err_text.contains("Line"));
+        assert!(err_text.contains("column") || err_text.contains("Column"));
+    }
 }


### PR DESCRIPTION
## Description
Updated cargo-budget-report to stop silently ignoring an invalid budget.toml. Introduced a dedicated loader that:
- returns defaults when budget.toml is missing,
- fails fast with a descriptive TOML parse error (including the parser message) when the file is present but invalid.

Also added regression tests covering the missing-file and malformed-file scenarios.

## Related Issue
Closes #7 

## Motivation and Context
Silently discarding a malformed budget.toml caused confusing behavior (missing network/source errors or ignored per-function `args`). This change surfaces TOML parse errors so users can fix configuration mistakes quickly and reliably.

## How Has This Been Tested?
- [x] Added/Updated tests
  - `missing_budget_toml_returns_default`
  - `malformed_budget_toml_errors_with_parse_message`
- [x] Passed `cargo test` for cargo-budget-report
- [ ] Passed `cargo clippy`
- [x] Formatted with `cargo fmt`

Repro / verification commands:
```bash
# From repository root
cargo fmt -p cargo-budget-report
cargo test -p cargo-budget-report
# Optional: run clippy locally
cargo clippy --workspace --all-targets -- -D warnings
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

