### PR TITLE
chore: run cargo test --workspace in CI

### DIFF
--- a/.github/workflows/budget.yml
+++ b/.github/workflows/budget.yml
@@ -33,7 +33,7 @@ jobs:
       run: cargo build -p amm-pool-contract --release --target wasm32-unknown-unknown
 
     - name: Run Budget Macros Test (Tier A)
-      run: cargo test
+      run: cargo test --workspace
 
     - name: Run Budget Report (Tier B)
       run: |


### PR DESCRIPTION
Closes #98

## Summary

Align the CI test command with the documented workspace-wide command from CONTRIBUTING.md.

The workflow previously ran cargo test, while the contribution guide instructs contributors to run cargo test --workspace. This change makes the Tier A CI step use the exact command documented in the repo so the workspace-level test coverage is enforced consistently.

## What changed

- Updated the Run Budget Macros Test (Tier A) step in .github/workflows/budget.yml
- Changed the workflow command from cargo test to cargo test --workspace

## Verification

I verified the change with the repo’s documented quality commands:

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

This keeps CI and contributor guidance aligned without bundling any unrelated workflow changes.