### PR TITLE
docs: add CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Added
+
+- Placeholder entry for upcoming user-visible changes.
+- Contributors should add a short changelog entry with their pull request when the change is user-visible.
+
+## [0.1.0] - 2026-07-24
+
+### Added
+
+- Budget assertion macros for local test-time cost checks:
+  - `#[budget_cpu_lt(N)]`
+  - `#[budget_mem_lt(N)]`
+- A workspace reporting CLI, `cargo budget-report`, that discovers Soroban contracts, builds them to WASM, deploys them to the configured network, simulates exported functions, and reports actual non-refundable execution costs.
+- `budget.toml` support for configuring the target network, source account, and per-function invoke arguments.
+- JSON output support for CI and automation workflows.
+- GitHub Actions integration for publishing budget history data to the repository's `gh-pages` history dataset.
+
+### Changed
+
+- Improved the user-facing CLI output to surface the network-verified execution metrics the project uses for budget decisions.
+
+### Notes
+
+- The current crate version numbers declared in the workspace manifests are `0.1.0`, so the initial changelog entry uses the same version number.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,8 +16,9 @@ First off, thank you for considering contributing to `soroban-budget-assert`!
 1. Fork the repo and create your branch from `main`.
 2. If you've added code that should be tested, add tests.
 3. If you've changed APIs, update the documentation.
-4. Ensure the test suite passes.
-5. Issue that pull request!
+4. Add a changelog entry in `CHANGELOG.md` for any user-visible change.
+5. Ensure the test suite passes.
+6. Issue that pull request!
 
 ## Local Development
 - Install Rust and the Soroban CLI.


### PR DESCRIPTION
## Summary
- Add a root changelog following Keep a Changelog conventions.
- Document the shipped 0.1.0 functionality as a grouped release entry.
- Add an `Unreleased` section for future entries.
- Update contributor guidance to require changelog entries for user-visible changes.

Closes #99