### PR TITLE
chore: create MEASUREMENTS.md as single source of truth for cost data

### DIFF
--- a/MEASUREMENTS.md
+++ b/MEASUREMENTS.md
@@ -1,0 +1,49 @@
+# Measurements
+
+This file records empirical cost measurements comparing local Soroban budget estimates against real network costs. Every measurement PR adds its numbers here so the series stays comparable and in one place.
+
+## Methodology
+
+Each measurement compares a local budget estimate against a network-verified figure for the same operation. The local estimate comes from `Env::cost_estimate().budget()` in a test that registers the contract as WASM with `register_contract_wasm` (except where noted). The network figure comes from `simulateTransaction` on Soroban testnet — the same endpoint the network uses to charge non-refundable resource costs.
+
+The WASM is compiled with the profile specified in the **Build profile** column. The direction of the local-vs-network gap is not stable across profiles; the same contract built with Cargo's default release profile can produce a gap pointing in the opposite direction of one built with the size-optimization profile. Every figure includes its build context.
+
+### Column reference
+
+| Column | Meaning |
+|---|---|
+| **Operation type** | Category of operation being measured |
+| **Local estimate** | Value reported by `Env::cost_estimate().budget()` in a WASM-registered local test |
+| **Network figure** | Value returned by `simulateTransaction` on Soroban testnet (ground truth) |
+| **Delta** | (local − network) / network, expressed as a percentage; positive means local overestimates |
+| **Fixture** | Contract, function, and arguments used for the measurement |
+| **Build profile** | Cargo profile used to compile the WASM |
+| **Toolchain** | Rust toolchain version (`rustc --version`) |
+| **Date** | Date the measurement was taken |
+
+## Existing measurements
+
+These figures were produced during the initial tool development and are published in the [Protocol Mechanics documentation](docs/src/mechanics.md). They serve as the worked example for contributors adding new measurements.
+
+### CPU instructions
+
+| Operation type | Local estimate | Network figure | Delta | Fixture | Build profile | Toolchain | Date |
+|---|---|---|---|---|---|---|---|
+| Mixed compute + storage (native Rust) | 143,887 | 756,678 | −81.0% | `amm-pool-contract::do_expensive_work(10_000)` | N/A (native test, no WASM) | rustc 1.81 | 2025-Q1 |
+| Mixed compute + storage (WASM) | 901,816 | 756,678 | +19.2% | `amm-pool-contract::do_expensive_work(10_000)` | size-opt (`opt-level="z"`, LTO, `codegen-units=1`) | rustc 1.81 | 2025-Q1 |
+| Mixed compute + storage (WASM) | 767,049 | 832,006 | −7.8% | `amm-pool-contract::do_expensive_work(10_000)` | default `release` (`opt-level=3`) | rustc 1.81 | 2025-Q1 |
+
+The native Rust row is included solely to illustrate that native estimates are unreliable for budget decisions. Only WASM-mode estimates should be used for assertions.
+
+All three rows measure the same `do_expensive_work(10_000)` function, which mixes a compute loop (`n` iterations of `wrapping_add(wrapping_mul)`) with a storage write (`Vec` of up to 100 elements written to `env.storage().instance().set`). The numbers are aggregate costs of both operations.
+
+## Unmeasured operation types
+
+The following operation types have open measurement issues and no published figures yet. When adding a measurement, follow the column format above and include the build profile and toolchain.
+
+| Operation type | Issue | Status |
+|---|---|---|
+| Storage-write operations | [#44](https://github.com/Tollcraft/soroban-budget-assert/issues/44) | Open |
+| Host-function-call operations | [#86](https://github.com/Tollcraft/soroban-budget-assert/issues/86) | Open |
+| VM-instruction-heavy operations | [#87](https://github.com/Tollcraft/soroban-budget-assert/issues/87) | Open |
+| Memory bytes | [#122](https://github.com/Tollcraft/soroban-budget-assert/issues/122) | Open |

--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ fn test_expensive_function() {
 
 ---
 
+## 📊 Measurements
+
+The [MEASUREMENTS.md](MEASUREMENTS.md) file at the repository root records all empirical cost measurements comparing local Soroban budget estimates against real network costs. The [Protocol Mechanics documentation](https://tollcraft.gitbook.io/docs/budget-assert/protocol-mechanics) cites this file as the source of truth for measured figures.
+
 ## 🤝 Community & Maintainers
 
 Join the discussion and get support:

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -6,3 +6,4 @@
 - [End-User Guide](user_guide.md)
 - [Developer Guide](developer_guide.md)
 - [Contributing](contributing.md)
+- [Measurements](../../MEASUREMENTS.md)

--- a/docs/src/mechanics.md
+++ b/docs/src/mechanics.md
@@ -4,14 +4,10 @@
 
 Every Soroban transaction runs against a resource budget. If the budget is exhausted on-chain, the transaction fails. Local tests estimate these costs, but the estimate depends on *how* the contract executes locally — and the error can point in either direction. Measured on the example contract's `do_expensive_work(10_000)`, built with the standard Soroban release profile (`opt-level = "z"`, LTO):
 
-| Execution mode | CPU instructions | Gap vs. testnet |
-|---|---|---|
-| Raw Rust (native test) | 143,887 | underestimates by ~81% |
-| Local WASM (`register_contract_wasm`) | 901,816 | overestimates by ~19% |
-| Testnet simulation (`simulateTransaction`) | 756,678 | ground truth |
+The raw figures and deltas are recorded in the [measurements file](../../MEASUREMENTS.md), which is the single source of truth for empirical cost data across the project. The same page documents the methodology, the build profiles tested, and the operation types not yet measured.
 
 {% hint style="info" %}
-The direction of the WASM gap is not stable. The same contract built with Cargo's *default* release profile measured 767,049 locally vs 832,006 on testnet — ~8% *under*. Applying the size-optimization profile flipped it to ~19% *over*: the smaller binary executes more instructions locally, while the network's cost model priced it lower.
+The direction of the WASM gap is not stable — see the two build profiles compared in the [existing measurements](../../MEASUREMENTS.md#cpu-instructions).
 {% endhint %}
 
 Two conclusions drive the tool's design:


### PR DESCRIPTION
Closes #130

## Summary

Creates `MEASUREMENTS.md` at the repository root as the single source of truth for empirical cost measurements, providing a defined structure that the measurement series (issues #44, #86, #87, #122) can write into.

### Changes

- **MEASUREMENTS.md** — New file with methodology, column reference table, existing CPU instruction measurements migrated from `docs/src/mechanics.md`, worked example rows, and an unmeasured operation types tracker linking to open issues.
- **docs/src/mechanics.md** — Removed inline measurement table to eliminate duplication; now cites `MEASUREMENTS.md` as the authoritative source for all figures.
- **README.md** — Added a "Measurements" section with a link to `MEASUREMENTS.md`.
- **docs/src/SUMMARY.md** — Added a "Measurements" entry linking to `../../MEASUREMENTS.md`.

### Why this matters

The four flagship measurement issues (#44, #86, #87, #122) all instruct contributors to "document numbers and computed delta in MEASUREMENTS.md" but the file did not exist. Every contributor would have invented their own format, making the series incomparable. This file defines the contract upfront.

### Implementation details

- Every row includes build profile and toolchain as required for reproducibility.
- The methodology is stated once so individual measurement PRs do not each restate it.
- No measurements were taken; this is purely a structural change.