### PR TITLE
fix: exit with non-zero code when contract simulations fail

### DIFF
--- a/cargo-budget-report/src/main.rs
+++ b/cargo-budget-report/src/main.rs
@@ -100,6 +100,7 @@ fn main() -> Result<()> {
         .context("failed to execute cargo metadata")?;
 
     let mut reports = Vec::new();
+    let mut has_errors = false;
 
     for package in metadata.packages {
         let is_cdylib = package
@@ -230,6 +231,7 @@ fn main() -> Result<()> {
                 .context("failed to execute stellar-cli invoke")?;
 
             if !invoke_output.status.success() {
+                has_errors = true;
                 eprintln!(
                     "Warning: Simulation failed for {}: {}",
                     function,
@@ -282,6 +284,7 @@ fn main() -> Result<()> {
                 .context("Failed to parse RPC response")?;
 
             if let Some(error) = rpc_resp.get("error") {
+                has_errors = true;
                 eprintln!("Warning: RPC error for {}: {}", function, error);
                 continue;
             }
@@ -338,6 +341,9 @@ fn main() -> Result<()> {
 
     if reports.is_empty() {
         eprintln!("No successful simulations to report.");
+        if has_errors {
+            std::process::exit(1);
+        }
         return Ok(());
     }
 
@@ -363,6 +369,10 @@ fn main() -> Result<()> {
         println!("{}", table);
         println!("\nSummary: The metrics above represent the total unrefundable network execution costs required to run your contract functions.");
         println!("* Note: These are simulated numbers on testnet and may vary slightly depending on ledger state.");
+    }
+
+    if has_errors {
+        std::process::exit(1);
     }
 
     Ok(())


### PR DESCRIPTION
## Description

Currently, when `simulateTransaction` RPC calls return errors (e.g., contract panics, missing arguments, invalid state), the tool logs a warning and skips to the next function but still exits with code 0. In CI/CD pipelines, this means builds pass green even when every simulation fails.

This PR tracks simulation failures with a `has_errors` flag and calls `std::process::exit(1)` at the end if any failures occurred. The report for successful functions is still printed before exiting.

## Related Issue
Closes #15

## Changes
- Added `let mut has_errors = false` flag before the workspace loop
- Set `has_errors = true` in both the invoke failure block and the RPC error block
- Exit with code 1 when `reports.is_empty()` and errors occurred
- Exit with code 1 after printing the report if any errors occurred

## Testing
- [ ] Passed `cargo test`
- [ ] Passed `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] Formatted with `cargo fmt --all -- --check`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
