### PR TITLE
fix: panic on unparseable env-var budget limit instead of silently disabling assertion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated GitHub Actions Pages deployment workflow to serve static site files from `./site`.
 - Contributors should add a short changelog entry with their pull request when the change is user-visible.
 
+### Fixed
+
+- Dynamic env-var budget limits (`env = "VAR"`) now panic with a clear message when the variable is set but contains an unparseable value (e.g. `1_000_000` or `"800000 "`), instead of silently falling back to `u64::MAX` and disabling the assertion.
+
 ## [0.1.0] - 2026-07-24
 
 ### Added

--- a/amm-pool-contract/tests/budget_test.rs
+++ b/amm-pool-contract/tests/budget_test.rs
@@ -121,3 +121,39 @@ fn test_budget_macro_dynamic_env_fallback() {
     client.swap(&user, &true, &100_i128, &90_i128);
     client.withdraw(&user, &1_000_i128, &900_i128, &900_i128);
 }
+
+#[test]
+#[should_panic(expected = "budget_cpu_lt: env var BAD_CPU_LIMIT")]
+#[budget_cpu_lt(env = "BAD_CPU_LIMIT")]
+fn test_budget_macro_dynamic_env_invalid_value() {
+    let budget_env_resolve = |var: &str| -> Option<String> {
+        if var == "BAD_CPU_LIMIT" {
+            Some("1_000_000".to_string())
+        } else {
+            None
+        }
+    };
+    let env = Env::default();
+    let contract_id = env.register(ConstantProductPool, ());
+    let client = ConstantProductPoolClient::new(&env, &contract_id);
+    env.cost_estimate().budget().reset_unlimited();
+    client.do_expensive_work(&10_000);
+}
+
+#[test]
+#[should_panic(expected = "budget_mem_lt: env var BAD_MEM_LIMIT")]
+#[budget_mem_lt(env = "BAD_MEM_LIMIT")]
+fn test_budget_macro_mem_dynamic_env_invalid_value() {
+    let budget_env_resolve = |var: &str| -> Option<String> {
+        if var == "BAD_MEM_LIMIT" {
+            Some("not_a_number".to_string())
+        } else {
+            None
+        }
+    };
+    let env = Env::default();
+    let contract_id = env.register(ConstantProductPool, ());
+    let client = ConstantProductPoolClient::new(&env, &contract_id);
+    env.cost_estimate().budget().reset_unlimited();
+    client.do_expensive_work(&10_000);
+}

--- a/budget-macros/src/lib.rs
+++ b/budget-macros/src/lib.rs
@@ -45,12 +45,25 @@ fn generate_budget_assert(
 
     let stmts = &input_fn.block.stmts;
 
+    let metric_label = match &metric {
+        BudgetMetric::CpuInstructionCost => "budget_cpu_lt",
+        BudgetMetric::MemoryBytesCost => "budget_mem_lt",
+    };
+
     let limit_expr = match limit {
         BudgetLimit::Int(n) => quote! { #n },
         BudgetLimit::EnvVar(var) => quote! {
-            budget_env_resolve(#var)
-                .and_then(|s| s.parse().ok())
-                .unwrap_or(u64::MAX)
+            match budget_env_resolve(#var) {
+                Some(s) => s.parse::<u64>().unwrap_or_else(|_| {
+                    panic!(
+                        "{}: env var {}={:?} is not a valid u64",
+                        #metric_label,
+                        #var,
+                        s
+                    )
+                }),
+                None => u64::MAX,
+            }
         },
     };
 
@@ -104,6 +117,10 @@ fn generate_budget_assert(
 /// significantly in either direction depending on the build profile — see
 /// `docs/src/mechanics.md` for measurements. Use `cargo budget-report` for
 /// network ground truth.
+///
+/// When using `env = "VAR"`, an unset environment variable means "no limit"
+/// (the assertion will always pass). The test will panic if the variable is
+/// set but its value cannot be parsed as a `u64`.
 #[proc_macro_attribute]
 pub fn budget_cpu_lt(attr: TokenStream, item: TokenStream) -> TokenStream {
     generate_budget_assert(attr, item, BudgetMetric::CpuInstructionCost)
@@ -116,6 +133,10 @@ pub fn budget_cpu_lt(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// significantly in either direction depending on the build profile — see
 /// `docs/src/mechanics.md` for measurements. Use `cargo budget-report` for
 /// network ground truth.
+///
+/// When using `env = "VAR"`, an unset environment variable means "no limit"
+/// (the assertion will always pass). The test will panic if the variable is
+/// set but its value cannot be parsed as a `u64`.
 #[proc_macro_attribute]
 pub fn budget_mem_lt(attr: TokenStream, item: TokenStream) -> TokenStream {
     generate_budget_assert(attr, item, BudgetMetric::MemoryBytesCost)


### PR DESCRIPTION
## Description

Fixes a bug where dynamic env-var budget limits (`env = \"VAR\"`) silently disabled the assertion when the variable was set to an unparseable value.

### The Bug

The dynamic limit form `#[budget_cpu_lt(env = \"MY_LIMIT\")]` previously expanded to:
```rust
budget_env_resolve(#var)
    .and_then(|s| s.parse().ok())
    .unwrap_or(u64::MAX)
```

Falling back to `u64::MAX` when the variable is unset is reasonable (\"no limit configured\"). But the same fallback applied when the variable was set but contained an unparseable value — e.g. `MY_LIMIT=1_000_000`, `MY_LIMIT=\"800000 \"`, or a typo like `80000O`. The assertion then compared against `u64::MAX` and passed vacuously: the developer believed their budget was enforced in CI when it was not.

### The Fix

The generated code now distinguishes between the two cases:

```rust
match budget_env_resolve(#var) {
    Some(s) => s.parse::<u64>().unwrap_or_else(|_| {
        panic!(\
            \"{}: env var {}={:?} is not a valid u64\",
            metric_label,
            #var,
            s
        )
    }),
    None => u64::MAX,
}
```

- **Unset variable** (`None`) → `u64::MAX` (unchanged behavior, \"no limit\")
- **Set but unparseable** (`Some(s)` where `s.parse()` fails) → panics with a clear message naming the macro and the offending value, e.g.:
  `budget_cpu_lt: env var MY_LIMIT=\"1_000_000\" is not a valid u64`

### Details

- **Shared code path** — the fix is in `generate_budget_assert`, so both `#[budget_cpu_lt]` and `#[budget_mem_lt]` get the fix automatically
- **Borrow-safe** — `metric_label` is computed via `match &metric` to avoid moving the value before its second use
- **Debug formatting** — the panic message uses `{:?}` for the value so whitespace and special characters are visible (e.g. trailing spaces)
- **Doc comments** — updated both macro doc comments to explain the unset/parse-error behavior

### Tests Added

Two `#[should_panic]` tests added to `amm-pool-contract/tests/budget_test.rs`:

- `test_budget_macro_dynamic_env_invalid_value` — `env = \"BAD_CPU_LIMIT\"` with value `\"1_000_000\"` (underscores not valid in bare `u64::parse`)
- `test_budget_macro_mem_dynamic_env_invalid_value` — `env = \"BAD_MEM_LIMIT\"` with value `\"not_a_number\"`

Both tests use raw Rust registration (no WASM needed) and follow the existing test patterns.

## Related Issue

Closes #8

## Motivation and Context

A developer setting `MY_LIMIT=1_000_000` in CI would expect the budget to be enforced at 1 million. Instead, `u64::parse` rejects the underscores, `.ok()` swallows the error, and `.unwrap_or(u64::MAX)` silently disables the check entirely. The test passes and the developer merges with a false sense of security. This fix turns that silent failure into a loud, actionable panic.

## How Has This Been Tested?

- [x] Added 2 new `#[should_panic]` tests — both pass
- [x] `cargo test -p budget-macros -p amm-pool-contract` — new tests pass; 6 pre-existing WASM-dependent tests fail due to missing WASM binary (same as before, resolved by CI build step)
- [x] `cargo clippy -p budget-macros -p amm-pool-contract -- -D warnings` — zero warnings
- [x] `cargo fmt --check --all` — correct format
- [x] `cargo build -p budget-macros -p amm-pool-contract` — succeeds

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added a changelog entry

---

**Diff stats:** 3 files, +64 / −3 lines  
**Branch:** `fix/env-var-invalid-value`