### PR TITLE
test: add comprehensive boundary tests for cost value formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Single-page landing site under `site/` with empirical cost-gap breakdown, two-tier architecture overview, quick-start guide, asciinema demo embed, and project resources.
 - Updated GitHub Actions Pages deployment workflow to serve static site files from `./site`.
+- Comprehensive unit tests for the cost-value formatter covering zero, single digits, thousands/millions boundaries, and `u32::MAX` across both unit suffixes.
 - Contributors should add a short changelog entry with their pull request when the change is user-visible.
 
 ## [0.1.0] - 2026-07-24

--- a/cargo-budget-report/src/main.rs
+++ b/cargo-budget-report/src/main.rs
@@ -873,7 +873,7 @@ mod tests {
     #[test]
     fn formatter_u32_max_cpu() {
         assert_eq!(
-            format_with_commas_and_units(u32::MAX, "CPU Instructions"),
+            format_with_commas_and_units(u64::from(u32::MAX), "CPU Instructions"),
             "4,294,967,295 inst."
         );
     }
@@ -881,7 +881,7 @@ mod tests {
     #[test]
     fn formatter_u32_max_bytes() {
         assert_eq!(
-            format_with_commas_and_units(u32::MAX, "Read Bytes"),
+            format_with_commas_and_units(u64::from(u32::MAX), "Read Bytes"),
             "4,294,967,295 B"
         );
     }

--- a/cargo-budget-report/src/main.rs
+++ b/cargo-budget-report/src/main.rs
@@ -619,4 +619,120 @@ mod tests {
             err_msg
         );
     }
+
+    // --- Cost value formatter tests ---
+
+    #[test]
+    fn formatter_zero_cpu() {
+        assert_eq!(
+            format_with_commas_and_units(0, "CPU Instructions"),
+            "0 inst."
+        );
+    }
+
+    #[test]
+    fn formatter_zero_bytes() {
+        assert_eq!(format_with_commas_and_units(0, "Read Bytes"), "0 B");
+    }
+
+    #[test]
+    fn formatter_single_digit_cpu() {
+        assert_eq!(
+            format_with_commas_and_units(7, "CPU Instructions"),
+            "7 inst."
+        );
+    }
+
+    #[test]
+    fn formatter_single_digit_bytes() {
+        assert_eq!(format_with_commas_and_units(3, "Write Bytes"), "3 B");
+    }
+
+    #[test]
+    fn formatter_just_below_thousand() {
+        assert_eq!(
+            format_with_commas_and_units(999, "CPU Instructions"),
+            "999 inst."
+        );
+    }
+
+    #[test]
+    fn formatter_at_thousand() {
+        assert_eq!(
+            format_with_commas_and_units(1_000, "CPU Instructions"),
+            "1,000 inst."
+        );
+    }
+
+    #[test]
+    fn formatter_just_above_thousand() {
+        assert_eq!(
+            format_with_commas_and_units(1_001, "CPU Instructions"),
+            "1,001 inst."
+        );
+    }
+
+    #[test]
+    fn formatter_just_below_million() {
+        assert_eq!(
+            format_with_commas_and_units(999_999, "Read Bytes"),
+            "999,999 B"
+        );
+    }
+
+    #[test]
+    fn formatter_at_million() {
+        assert_eq!(
+            format_with_commas_and_units(1_000_000, "CPU Instructions"),
+            "1,000,000 inst."
+        );
+    }
+
+    #[test]
+    fn formatter_just_above_million() {
+        assert_eq!(
+            format_with_commas_and_units(1_000_001, "Write Bytes"),
+            "1,000,001 B"
+        );
+    }
+
+    #[test]
+    fn formatter_ten_million() {
+        assert_eq!(
+            format_with_commas_and_units(10_000_000, "CPU Instructions"),
+            "10,000,000 inst."
+        );
+    }
+
+    #[test]
+    fn formatter_u32_max_cpu() {
+        assert_eq!(
+            format_with_commas_and_units(u32::MAX, "CPU Instructions"),
+            "4,294,967,295 inst."
+        );
+    }
+
+    #[test]
+    fn formatter_u32_max_bytes() {
+        assert_eq!(
+            format_with_commas_and_units(u32::MAX, "Read Bytes"),
+            "4,294,967,295 B"
+        );
+    }
+
+    #[test]
+    fn formatter_write_bytes_gets_byte_unit() {
+        assert_eq!(
+            format_with_commas_and_units(4_096, "Write Bytes"),
+            "4,096 B"
+        );
+    }
+
+    #[test]
+    fn formatter_non_bytes_metric_gets_inst_unit() {
+        assert_eq!(
+            format_with_commas_and_units(500, "Some Other Metric"),
+            "500 inst."
+        );
+    }
 }


### PR DESCRIPTION
## Description

Adds comprehensive unit tests for `format_with_commas_and_units` — the function that hand-rolls thousands separators and appends unit suffixes. This is the only pure function in the binary crate and every user-facing number passes through it, yet it previously had zero test coverage.

### What was added

15 new unit tests in `#[cfg(test)] mod tests` covering every documented boundary:

| Category | Tests | Values covered |
|----------|-------|---------------|
| **Zero** | `formatter_zero_cpu`, `formatter_zero_bytes` | `0` with both `\" inst.\"` and `\" B\"` |
| **Single digits** | `formatter_single_digit_cpu`, `formatter_single_digit_bytes` | `7`, `3` with both suffixes |
| **Below thousand** | `formatter_just_below_thousand` | `999` (no comma yet) |
| **At thousand** | `formatter_at_thousand` | `1_000` (first comma appears) |
| **Above thousand** | `formatter_just_above_thousand` | `1_001` (comma present) |
| **Below million** | `formatter_just_below_million` | `999_999` (two groups, no third comma yet) |
| **At million** | `formatter_at_million` | `1_000_000` (two commas) |
| **Above million** | `formatter_just_above_million` | `1_000_001` (two commas) |
| **Two-digit front group** | `formatter_ten_million` | `10_000_000` (two-digit group before first comma) |
| **u32::MAX** | `formatter_u32_max_cpu`, `formatter_u32_max_bytes` | `4_294_967_295` with both suffixes |
| **Unit logic** | `formatter_write_bytes_gets_byte_unit`, `formatter_non_bytes_metric_gets_inst_unit` | `\"Write Bytes\"` → `\" B\"`, non-\"Bytes\" → `\" inst.\"` |

### Bug finding

No bugs were found. The comma-insertion algorithm (reverse → insert commas every 3 chars → reverse back) produces correct output for all tested inputs, including the `\"2-digit group before first comma\"` case (`10,000,000`) that could have been a fencepost error.

### Design note

The tests live in a `#[cfg(test)]` module in the binary crate (not a separate library). This is intentional — issue #25 tracks library extraction, and these tests will move cleanly when that happens.

## Related Issue

Closes #115

## Motivation and Context

`format_with_commas_and_units` is the only pure function in the file and it had no tests. It hand-rolls thousands separators by reversing a string, counting characters, and reversing back. The hand-rolled grouping has boundary conditions — zero, values under 1000, values at exact multiples of 1000, `u32::MAX` — and nothing previously checked any of them.

## How Has This Been Tested?

- [x] Added 15 new unit tests — all pass (26/26 total)
- [x] `cargo test -p cargo-budget-report` — 26/26 passing
- [x] `cargo clippy -p cargo-budget-report -- -D warnings` — zero warnings
- [x] `cargo fmt --check -p cargo-budget-report` — correct format
- [x] `cargo build -p cargo-budget-report` — succeeds

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Test coverage (non-functional change)
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added a changelog entry

---

**Diff stats:** 2 files, +117 / −0 lines  
**Branch:** `test/cost-value-formatter`