### PR TITLE
docs: remind contributors to review budget limits

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,6 +14,7 @@ Closes #
 - [ ] Passed `cargo test`
 - [ ] Passed `cargo clippy`
 - [ ] Formatted with `cargo fmt`
+- [ ] Reviewed or re-measured budget limits in `amm-pool-contract/tests/budget_test.rs` when contract, build profile, or toolchain changes may affect them
 
 ## Types of changes
 <!-- What types of changes does your code introduce? -->


### PR DESCRIPTION
Closes #127

---

## Summary
Add a budget-limit review reminder to the PR template so contributors are prompted to re-measure pinned budget limits when relevant changes may affect them.

## What changed
- Expanded the testing checklist in [.github/pull_request_template.md](.github/pull_request_template.md) with a checkbox to review or re-measure the budget limits in [amm-pool-contract/tests/budget_test.rs](amm-pool-contract/tests/budget_test.rs).

## Why
The repository’s budget tests use pinned limits that can silently become stale when the contract, build profile, or toolchain changes. This reminder makes that risk visible during PR review.

## Acceptance criteria
- [x] PR template includes a budget-limit review reminder
- [x] Reminder points contributors to the budget test file that contains the pinned limits

## Testing
- Not applicable; this is a documentation-only change.