### PR TITLE
chore: implement a pre-commit hook for formatting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,3 +32,17 @@ Before submitting a pull request, please ensure your code meets our quality stan
 - `cargo test --workspace`
 
 Please follow the styling and architectural patterns already used in the codebase.
+
+### Pre-commit hook
+
+To catch formatting issues automatically before they reach CI, install the
+repository's pre-commit hook once after cloning:
+
+```bash
+bash scripts/install-hooks.sh
+```
+
+This runs `cargo fmt --all -- --check` before every commit and blocks the
+commit if formatting is off. Fix with `cargo fmt --all` and commit again.
+The hook only checks formatting — clippy and tests are intentionally left
+to CI and the manual pre-PR checklist above, since they take longer to run.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -333,6 +333,7 @@ dependencies = [
  "serde_json",
  "stellar-xdr",
  "tabled",
+ "tempfile",
  "toml",
  "wasmparser",
 ]

--- a/cargo-budget-report/Cargo.toml
+++ b/cargo-budget-report/Cargo.toml
@@ -20,3 +20,6 @@ toml = "0.8"
 cargo_metadata = "0.18"
 wasmparser = "0.116.1"
 indicatif = "0.17.8"
+
+[dev-dependencies]
+tempfile = "3"

--- a/cargo-budget-report/tests/pre_commit_hook.rs
+++ b/cargo-budget-report/tests/pre_commit_hook.rs
@@ -1,0 +1,145 @@
+//! Integration test for `scripts/pre-commit` + `scripts/install-hooks.sh`.
+//!
+//! Since these are shell scripts, not Rust code, the only meaningful test is
+//! behavioral: install the hook into a real scratch git repository and verify
+//! it actually blocks a commit when `cargo fmt --all -- --check` would fail,
+//! and allows the commit once formatting is fixed.
+
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+/// Absolute path to the real repository root (where `scripts/` lives),
+/// regardless of the cwd the test binary is invoked from.
+fn repo_root() -> std::path::PathBuf {
+    let manifest_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    manifest_dir
+        .parent()
+        .expect("cargo-budget-report has a parent directory")
+        .to_path_buf()
+}
+
+/// Builds a throwaway git + cargo project in `dir`, installs the real
+/// `scripts/install-hooks.sh` / `scripts/pre-commit` into it, and returns
+/// once the hook is in place.
+fn setup_scratch_repo(dir: &Path) {
+    fs::create_dir_all(dir.join("src")).unwrap();
+    fs::write(
+        dir.join("Cargo.toml"),
+        "[package]\nname = \"scratch\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+    )
+    .unwrap();
+
+    let status = Command::new("git")
+        .args(["init"])
+        .current_dir(dir)
+        .status()
+        .expect("git init should run");
+    assert!(status.success(), "git init failed");
+
+    // Minimal identity so `git commit` doesn't fail on a fresh CI/dev machine.
+    Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(dir)
+        .status()
+        .unwrap();
+    Command::new("git")
+        .args(["config", "user.name", "Test"])
+        .current_dir(dir)
+        .status()
+        .unwrap();
+
+    let real_scripts_dir = repo_root().join("scripts");
+    let scratch_scripts_dir = dir.join("scripts");
+    fs::create_dir_all(&scratch_scripts_dir).unwrap();
+    fs::copy(
+        real_scripts_dir.join("pre-commit"),
+        scratch_scripts_dir.join("pre-commit"),
+    )
+    .unwrap();
+    fs::copy(
+        real_scripts_dir.join("install-hooks.sh"),
+        scratch_scripts_dir.join("install-hooks.sh"),
+    )
+    .unwrap();
+
+    let status = Command::new("bash")
+        .arg("scripts/install-hooks.sh")
+        .current_dir(dir)
+        .status()
+        .expect("install-hooks.sh should run");
+    assert!(status.success(), "install-hooks.sh failed");
+
+    assert!(
+        dir.join(".git/hooks/pre-commit").exists(),
+        "hook was not installed at .git/hooks/pre-commit"
+    );
+}
+
+fn git_add_all(dir: &Path) {
+    let status = Command::new("git")
+        .args(["add", "."])
+        .current_dir(dir)
+        .status()
+        .unwrap();
+    assert!(status.success());
+}
+
+fn git_commit(dir: &Path, message: &str) -> std::process::Output {
+    Command::new("git")
+        .args(["commit", "-m", message])
+        .current_dir(dir)
+        .output()
+        .expect("git commit should run")
+}
+
+#[test]
+fn pre_commit_hook_blocks_badly_formatted_code() {
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    let dir = tmp.path();
+    setup_scratch_repo(dir);
+
+    // Deliberately malformed: extra spaces, no rustfmt-standard layout.
+    fs::write(
+        dir.join("src/lib.rs"),
+        "pub fn add(a:i32,b:i32)->i32{a+b}\n",
+    )
+    .unwrap();
+
+    git_add_all(dir);
+    let output = git_commit(dir, "add badly formatted code");
+
+    assert!(
+        !output.status.success(),
+        "commit should have been blocked by the pre-commit hook"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Formatting check failed") || stderr.contains("Formatting check failed"),
+        "expected hook's failure message in output, got stdout={stdout:?} stderr={stderr:?}"
+    );
+}
+
+#[test]
+fn pre_commit_hook_allows_well_formatted_code() {
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    let dir = tmp.path();
+    setup_scratch_repo(dir);
+
+    fs::write(
+        dir.join("src/lib.rs"),
+        "pub fn add(a: i32, b: i32) -> i32 {\n    a + b\n}\n",
+    )
+    .unwrap();
+
+    git_add_all(dir);
+    let output = git_commit(dir, "add well formatted code");
+
+    assert!(
+        output.status.success(),
+        "commit should have succeeded; stdout={:?} stderr={:?}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Installs repository git hooks (currently: pre-commit formatting check).
+#
+# Run once after cloning: `bash scripts/install-hooks.sh`
+
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+hook_source="$repo_root/scripts/pre-commit"
+hook_target="$repo_root/.git/hooks/pre-commit"
+
+cp "$hook_source" "$hook_target"
+chmod +x "$hook_target"
+
+echo "✅ Installed pre-commit hook -> $hook_target"

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Pre-commit hook: enforce `cargo fmt` formatting before allowing a commit.
+#
+# Installed via `scripts/install-hooks.sh`. Runs on every `git commit`.
+# Only checks formatting (matches CONTRIBUTING.md's `cargo fmt --all -- --check`);
+# clippy and tests are intentionally left to CI / manual pre-PR checks since
+# they're slower and this hook should stay fast enough to run on every commit.
+
+set -euo pipefail
+
+if ! cargo fmt --all -- --check; then
+    echo ""
+    echo "❌ Formatting check failed."
+    echo "   Run 'cargo fmt --all' to fix, then commit again."
+    exit 1
+fi


### PR DESCRIPTION
## Summary

This PR adds a formatting-only pre-commit hook to help contributors catch formatting issues before commits are created.

### Changes

* Added `scripts/pre-commit` to run `cargo fmt --all -- --check` before each commit.
* Added `scripts/install-hooks.sh` to install the hook into `.git/hooks/pre-commit`.
* Updated `CONTRIBUTING.md` with instructions for installing and using the pre-commit hook.
* Added an integration test (`cargo-budget-report/tests/pre_commit_hook.rs`) that:

  * Verifies commits are blocked when Rust code is not properly formatted.
  * Verifies commits succeed when formatting checks pass.
* Added `tempfile` as a development dependency for the integration tests.

## Related Issue

Closes #83

## Testing

Successfully ran:

```bash
cargo test -p cargo-budget-report --test pre_commit_hook
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo build --target wasm32-unknown-unknown --release -p amm-pool-contract
cargo test --workspace
```

## Notes

* The pre-commit hook intentionally performs **only formatting checks** (`cargo fmt --all -- --check`) to match the scope of Issue #83.
* The installation script is provided because Git hooks are not version-controlled and must be installed locally by each contributor.
* The integration test validates the complete installation and execution flow using temporary Git repositories, ensuring the hook behaves correctly in real-world usage.
