### PR TITLE
fix(macros): run budget assertion on every test exit path

### DIFF
--- a/amm-pool-contract/tests/budget_test.rs
+++ b/amm-pool-contract/tests/budget_test.rs
@@ -473,3 +473,75 @@ fn test_write_bytes_budget_regression() {
     // Even a single entry will exceed a limit of 1 byte.
     client.do_write_heavy_work(&1);
 }
+
+// ---------------------------------------------------------------------------
+// Test body shapes (issue #6)
+//
+// The assertion is injected on every path that leaves the test, so these body
+// shapes are supported: a trailing expression (`-> Result<_, _>` tests) and an
+// early `return`. budget-macros/tests/ui.rs covers the same shapes at the token
+// level, against a mock `env` and without a WASM build.
+// ---------------------------------------------------------------------------
+
+// A generous limit on purpose: this test pins the *body shape* (the check runs
+// after the `Ok(())` tail and the value is still returned), not a cost figure,
+// so it must not need re-measuring whenever the WASM build changes. The tight
+// limits live in the tests above that exist to measure cost.
+#[test]
+#[budget_cpu_lt(50000000)]
+fn test_budget_macro_result_returning() -> Result<(), std::num::ParseIntError> {
+    let env = Env::default();
+    let (client, user) = setup_wasm(&env);
+
+    let amount: i128 = "10000".parse::<u32>()?.into();
+    client.deposit(&user, &amount, &amount);
+    client.swap(&user, &true, &100_i128, &90_i128);
+
+    Ok(())
+}
+
+// `#[should_panic]` requires a test returning `()`, so the `Result` regression is
+// caught by hand instead.
+#[test]
+fn test_budget_macro_result_returning_regression() {
+    #[budget_cpu_lt(1)]
+    fn measured() -> Result<(), std::num::ParseIntError> {
+        let env = Env::default();
+        let (client, user) = setup_wasm(&env);
+
+        let amount: i128 = "10000".parse::<u32>()?.into();
+        client.deposit(&user, &amount, &amount);
+
+        Ok(())
+    }
+
+    let payload = std::panic::catch_unwind(measured)
+        .expect_err("the budget assertion should have failed at a 1 instruction limit");
+    let message = payload
+        .downcast_ref::<String>()
+        .cloned()
+        .unwrap_or_default();
+    assert!(
+        message.contains("local estimate, real network cost may differ significantly"),
+        "unexpected panic message: {message}"
+    );
+}
+
+#[test]
+#[should_panic(
+    expected = "local estimate, real network cost may differ significantly in either direction"
+)]
+#[budget_mem_lt(1)]
+fn test_budget_macro_early_return_still_asserts() {
+    let env = Env::default();
+    let (client, user) = setup_wasm(&env);
+
+    client.deposit(&user, &10_000_i128, &10_000_i128);
+
+    if std::env::var("TEST_RUN_FULL_BODY").is_err() {
+        // Used to exit without ever measuring the budget.
+        return;
+    }
+
+    client.swap(&user, &true, &100_i128, &90_i128);
+}

--- a/budget-macros/Cargo.toml
+++ b/budget-macros/Cargo.toml
@@ -11,7 +11,7 @@ readme.workspace = true
 proc-macro = true
 
 [dependencies]
-syn = { version = "2.0", features = ["full", "extra-traits"] }
+syn = { version = "2.0", features = ["full", "extra-traits", "visit-mut"] }
 quote = "1.0"
 proc-macro2 = "1.0"
 serde_json = "1.0"

--- a/budget-macros/src/lib.rs
+++ b/budget-macros/src/lib.rs
@@ -1,8 +1,13 @@
 extern crate proc_macro;
 
 use proc_macro::TokenStream;
+use proc_macro2::{Span, TokenStream as TokenStream2, TokenTree};
 use quote::quote;
-use syn::{parse::Parse, parse::ParseStream, Ident, ItemFn, LitInt, LitStr, Token};
+use syn::visit_mut::{self, VisitMut};
+use syn::{
+    parse::Parse, parse::ParseStream, parse_quote, Expr, Ident, Item, ItemFn, LitInt, LitStr,
+    Macro, Stmt, Token,
+};
 
 #[derive(Clone)]
 enum BudgetLimit {
@@ -205,13 +210,171 @@ fn generate_limit_expr(limit: &BudgetLimit, metric_label: &str) -> proc_macro2::
     }
 }
 
+const MACRO_RETURN_ERROR: &str = "`return` inside a macro invocation is not supported by the \
+     budget macros: the assertion cannot be injected into macro tokens, so it would be skipped \
+     silently. Move the `return` out of the macro invocation, or end the test with a tail \
+     expression instead. (If this `return` belongs to a closure passed to the macro, lift the \
+     closure into a `let` binding before the macro call.)";
+
+/// Rewrites the test body so the budget assertion runs on every path that leaves
+/// the test function.
+///
+/// `return e` becomes `return { let v = e; <assertion>; v }`, which keeps the
+/// expression's `!` type (so `return` in value position still type-checks) and
+/// evaluates `e` before measuring, so the returned value's own cost is counted.
+///
+/// `return`s belonging to a nested closure, `async` block, or nested item exit
+/// that inner body rather than the test, so those are left untouched. `return`s
+/// hidden inside macro invocation tokens cannot be rewritten and are collected
+/// so the caller can report them.
+struct ReturnRewriter {
+    assertion: TokenStream2,
+    macro_returns: Vec<Span>,
+}
+
+impl VisitMut for ReturnRewriter {
+    fn visit_expr_mut(&mut self, expr: &mut Expr) {
+        // A `return` in here leaves the closure/async body, not the test function.
+        if matches!(expr, Expr::Closure(_) | Expr::Async(_)) {
+            return;
+        }
+
+        // Rewrite inner expressions first so the injected assertion is not revisited.
+        visit_mut::visit_expr_mut(self, expr);
+
+        if let Expr::Return(ret) = expr {
+            let assertion = &self.assertion;
+            *expr = match ret.expr.take() {
+                Some(value) => parse_quote! {
+                    return {
+                        let __budget_returned = #value;
+                        #assertion
+                        __budget_returned
+                    }
+                },
+                None => parse_quote! {
+                    return {
+                        #assertion
+                    }
+                },
+            };
+        }
+    }
+
+    fn visit_item_mut(&mut self, _item: &mut Item) {
+        // Nested items (e.g. helper `fn`s declared in the body) have their own returns.
+    }
+
+    fn visit_macro_mut(&mut self, mac: &mut Macro) {
+        if let Some(span) = find_return_token(mac.tokens.clone()) {
+            self.macro_returns.push(span);
+        }
+    }
+}
+
+/// Finds a `return` token anywhere in a macro's token stream.
+fn find_return_token(tokens: TokenStream2) -> Option<Span> {
+    for token in tokens {
+        match token {
+            TokenTree::Ident(ident) if ident == "return" => return Some(ident.span()),
+            TokenTree::Group(group) => {
+                if let Some(span) = find_return_token(group.stream()) {
+                    return Some(span);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Rebuilds `input_fn`'s body as `prelude`, the original statements, and
+/// `assertion` on every path that leaves the function.
+///
+/// A trailing expression is bound before the assertion and yielded afterwards, so
+/// it stays the function's value and `-> Result<_, _>` bodies compile; early
+/// `return`s carry the assertion via [`ReturnRewriter`]. Returns the tokens to
+/// emit instead when the body has a `return` the rewrite cannot reach.
+fn instrument_exit_paths(
+    input_fn: &mut ItemFn,
+    prelude: TokenStream2,
+    assertion: TokenStream2,
+) -> Option<TokenStream> {
+    let mut rewriter = ReturnRewriter {
+        assertion: assertion.clone(),
+        macro_returns: Vec::new(),
+    };
+    let original_fn = input_fn.clone();
+    rewriter.visit_block_mut(&mut input_fn.block);
+
+    if !rewriter.macro_returns.is_empty() {
+        let errors = rewriter
+            .macro_returns
+            .iter()
+            .map(|span| syn::Error::new(*span, MACRO_RETURN_ERROR).to_compile_error());
+        // Emit the untouched function too, so the only error reported is ours.
+        return Some(TokenStream::from(quote! {
+            #(#errors)*
+            #original_fn
+        }));
+    }
+
+    // A trailing expression is the function's value (e.g. `Ok(())`), so it has to
+    // be bound before the assertion and yielded afterwards. A trailing `return`
+    // already carries the assertion from the rewrite above.
+    let tail = match input_fn.block.stmts.last() {
+        Some(Stmt::Expr(expr, None)) if !matches!(expr, Expr::Return(_)) => {
+            match input_fn.block.stmts.pop() {
+                Some(Stmt::Expr(expr, None)) => Some(expr),
+                _ => unreachable!("last statement was just matched as a trailing expression"),
+            }
+        }
+        _ => None,
+    };
+
+    let stmts = &input_fn.block.stmts;
+    let new_block = match tail {
+        Some(tail) => quote! {
+            {
+                #prelude
+
+                #(#stmts)*
+
+                let __budget_value = #tail;
+                #assertion
+                __budget_value
+            }
+        },
+        None => quote! {
+            {
+                #prelude
+
+                #(#stmts)*
+
+                #assertion
+            }
+        },
+    };
+
+    *input_fn.block = match syn::parse2(new_block) {
+        Ok(block) => block,
+        Err(e) => return Some(TokenStream::from(e.to_compile_error())),
+    };
+    // A body ending in `return`/`panic!` makes the trailing assertion unreachable;
+    // the paths that do reach an exit already asserted.
+    input_fn
+        .attrs
+        .push(parse_quote!(#[allow(unreachable_code)]));
+
+    None
+}
+
 fn generate_budget_assert(spec: BudgetSpec, item: TokenStream) -> TokenStream {
     let mut input_fn = match syn::parse2::<ItemFn>(item.into()) {
         Ok(f) => f,
         Err(e) => return TokenStream::from(e.to_compile_error()),
     };
 
-    let stmts = &input_fn.block.stmts;
     let env_ident = spec
         .env_ident
         .unwrap_or_else(|| proc_macro2::Ident::new("env", proc_macro2::Span::call_site()));
@@ -252,24 +415,27 @@ fn generate_budget_assert(spec: BudgetSpec, item: TokenStream) -> TokenStream {
         });
     }
 
-    let new_block = quote! {
+    let prelude = quote! {
+        #[allow(unused_variables)]
+        let budget_env_resolve = |var: &str| -> Option<String> {
+            std::env::var(var).ok()
+        };
+    };
+
+    // Injected at every path that leaves the test, not just after the last
+    // statement, so an early `return` cannot skip it. It stays inside the body's
+    // scope so each limit still resolves against the body's own bindings — tests
+    // that shadow `budget_env_resolve` rely on that.
+    let assertion = quote! {
         {
-            #[allow(unused_variables)]
-            let budget_env_resolve = |var: &str| -> Option<String> {
-                std::env::var(var).ok()
-            };
-
-            #(#stmts)*
-
             let budget = #env_ident.cost_estimate().budget();
             #(#asserts)*
         }
     };
 
-    *input_fn.block = match syn::parse2(new_block) {
-        Ok(block) => block,
-        Err(e) => return TokenStream::from(e.to_compile_error()),
-    };
+    if let Some(tokens) = instrument_exit_paths(&mut input_fn, prelude, assertion) {
+        return tokens;
+    }
 
     TokenStream::from(quote! {
         #input_fn
@@ -279,8 +445,11 @@ fn generate_budget_assert(spec: BudgetSpec, item: TokenStream) -> TokenStream {
 /// Asserts that the CPU instructions used by `env` are strictly less than a specified limit.
 ///
 /// Must be placed on a test function that contains a local `env` variable (a `soroban_sdk::Env`).
-/// The macro appends an assertion check to the body of the test function that measures
-/// `env.cost_estimate().budget().cpu_instruction_cost()`.
+/// The macro injects an assertion check that measures
+/// `env.cost_estimate().budget().cpu_instruction_cost()` on every path that leaves the test
+/// function, so bodies ending in a tail expression (`fn test() -> Result<(), Error>`)
+/// and bodies with early `return`s are both supported. A `?` that propagates an error
+/// skips the check, but the test fails on that error anyway.
 ///
 /// # Local Estimates vs Network Costs
 ///
@@ -347,11 +516,80 @@ pub fn budget_cpu_lt(attr: TokenStream, item: TokenStream) -> TokenStream {
     )
 }
 
+/// Asserts that the ledger write bytes used by `env` are less than N.
+///
+/// Write bytes represent the total bytes written to ledger storage during
+/// contract execution. This macro measures the local `memory_bytes_cost` as a
+/// proxy, which correlates with storage serialization overhead even though the
+/// exact on-network write-bytes figure is only available via RPC simulation.
+/// Must be placed on a test function that has a local `env` variable.
+#[proc_macro_attribute]
+pub fn budget_write_bytes_lt(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let limit = match syn::parse::<BudgetLimit>(attr) {
+        Ok(l) => l,
+        Err(e) => return TokenStream::from(e.to_compile_error()),
+    };
+    let mut input_fn = match syn::parse::<ItemFn>(item) {
+        Ok(f) => f,
+        Err(e) => return TokenStream::from(e.to_compile_error()),
+    };
+
+    let limit_expr = match limit {
+        BudgetLimit::Int(n) => quote! { #n },
+        BudgetLimit::EnvVar(var) => quote! {
+            std::env::var(#var)
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(u64::MAX)
+        },
+        BudgetLimit::Config(key) => quote! {
+            std::fs::read_to_string(std::path::Path::new("budget.json"))
+                .ok()
+                .map(|content| {
+                    parse_config_value(&content, #key).unwrap_or_else(|| {
+                        panic!(
+                            "budget_write_bytes_lt: key '{}' not found or invalid in budget.json",
+                            #key,
+                        )
+                    })
+                })
+                .unwrap_or(u64::MAX)
+        },
+    };
+
+    let env_ident = proc_macro2::Ident::new("env", proc_macro2::Span::call_site());
+
+    // Same exit-path instrumentation as the other budget macros.
+    let assertion = quote! {
+        {
+            let budget = #env_ident.cost_estimate().budget();
+            let write_bytes_cost = budget.memory_bytes_cost();
+            let limit_u64: u64 = #limit_expr;
+            assert!(
+                write_bytes_cost < limit_u64,
+                "Write bytes cost (memory proxy) {} exceeded limit {} - local estimate, underestimates real network cost",
+                write_bytes_cost,
+                limit_u64
+            );
+        }
+    };
+
+    if let Some(tokens) = instrument_exit_paths(&mut input_fn, quote! {}, assertion) {
+        return tokens;
+    }
+
+    TokenStream::from(quote! {
+        #input_fn
+    })
+}
 /// Asserts that the memory bytes used by `env` are strictly less than a specified limit.
 ///
 /// Must be placed on a test function that contains a local `env` variable (a `soroban_sdk::Env`).
-/// The macro appends an assertion check to the body of the test function that measures
-/// `env.cost_estimate().budget().memory_bytes_cost()`.
+/// The macro injects an assertion check that measures
+/// `env.cost_estimate().budget().memory_bytes_cost()` on every path that leaves the test
+/// function, so bodies ending in a tail expression (`fn test() -> Result<(), Error>`)
+/// and bodies with early `return`s are both supported. A `?` that propagates an error
+/// skips the check, but the test fails on that error anyway.
 ///
 /// # Local Estimates vs Network Costs
 ///
@@ -402,74 +640,6 @@ pub fn budget_cpu_lt(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///   allowing the test assertion to pass unconditionally.
 /// - If the environment variable is set to a string that **cannot be parsed as a `u64`**,
 ///   the test panics at runtime with an explicit error naming the variable and invalid value.
-
-/// Asserts that the ledger write bytes used by `env` are less than N.
-///
-/// Write bytes represent the total bytes written to ledger storage during
-/// contract execution. This macro measures the local `memory_bytes_cost` as a
-/// proxy, which correlates with storage serialization overhead even though the
-/// exact on-network write-bytes figure is only available via RPC simulation.
-/// Must be placed on a test function that has a local `env` variable.
-#[proc_macro_attribute]
-pub fn budget_write_bytes_lt(attr: TokenStream, item: TokenStream) -> TokenStream {
-    let limit = match syn::parse::<BudgetLimit>(attr) {
-        Ok(l) => l,
-        Err(e) => return TokenStream::from(e.to_compile_error()),
-    };
-    let mut input_fn = match syn::parse::<ItemFn>(item) {
-        Ok(f) => f,
-        Err(e) => return TokenStream::from(e.to_compile_error()),
-    };
-
-    let stmts = &input_fn.block.stmts;
-
-    let limit_expr = match limit {
-        BudgetLimit::Int(n) => quote! { #n },
-        BudgetLimit::EnvVar(var) => quote! {
-            std::env::var(#var)
-                .ok()
-                .and_then(|s| s.parse().ok())
-                .unwrap_or(u64::MAX)
-        },
-        BudgetLimit::Config(key) => quote! {
-            std::fs::read_to_string(std::path::Path::new("budget.json"))
-                .ok()
-                .map(|content| {
-                    parse_config_value(&content, #key).unwrap_or_else(|| {
-                        panic!(
-                            "budget_write_bytes_lt: key '{}' not found or invalid in budget.json",
-                            #key,
-                        )
-                    })
-                })
-                .unwrap_or(u64::MAX)
-        },
-    };
-
-    let env_ident = proc_macro2::Ident::new("env", proc_macro2::Span::call_site());
-
-    let new_block = quote! {
-        {
-            #(#stmts)*
-
-            let budget = #env_ident.cost_estimate().budget();
-            let write_bytes_cost = budget.memory_bytes_cost();
-            let limit_u64: u64 = #limit_expr;
-            assert!(
-                write_bytes_cost < limit_u64,
-                "Write bytes cost (memory proxy) {} exceeded limit {} - local estimate, underestimates real network cost",
-                write_bytes_cost,
-                limit_u64
-            );
-        }
-    };
-
-    *input_fn.block = syn::parse2(new_block).unwrap();
-
-    TokenStream::from(quote! {
-        #input_fn
-    })
-}
 #[proc_macro_attribute]
 pub fn budget_mem_lt(attr: TokenStream, item: TokenStream) -> TokenStream {
     let limit = match syn::parse2::<BudgetLimit>(attr.into()) {

--- a/budget-macros/tests/ui.rs
+++ b/budget-macros/tests/ui.rs
@@ -1,5 +1,16 @@
+//! Compile-time behavior of the budget macros.
+//!
+//! `tests/ui/*.rs` must fail to compile, with the diagnostic pinned in the
+//! matching `.stderr`. `tests/ui/pass/*.rs` must compile *and run*: those cases
+//! exercise each supported test-body shape against the mock `env` in
+//! `tests/ui/support/mock_env.rs` and assert which cost and limit the injected
+//! check reports, so a body shape that silently stops being checked fails here.
+//!
+//! Regenerate the `.stderr` snapshots with `TRYBUILD=overwrite cargo test -p budget-macros`.
+
 #[test]
 fn ui_tests() {
     let t = trybuild::TestCases::new();
     t.compile_fail("tests/ui/*.rs");
+    t.pass("tests/ui/pass/*.rs");
 }

--- a/budget-macros/tests/ui/fail_return_in_macro.rs
+++ b/budget-macros/tests/ui/fail_return_in_macro.rs
@@ -1,0 +1,26 @@
+//! A `return` written inside macro invocation tokens cannot be rewritten, so it
+//! is rejected instead of silently skipping the budget assertion.
+
+#[path = "support/mock_env.rs"]
+mod mock_env;
+
+use budget_macros::budget_cpu_lt;
+use mock_env::Env;
+
+#[derive(Debug)]
+struct TestError;
+
+#[budget_cpu_lt(1_000)]
+fn return_inside_macro(exit_early: bool) -> Result<(), TestError> {
+    let env = Env::new(999, 0);
+    assert!(if exit_early {
+        return Err(TestError)
+    } else {
+        env.cost_estimate().budget().cpu_instruction_cost() < 1_000
+    });
+    Ok(())
+}
+
+fn main() {
+    let _ = return_inside_macro(true);
+}

--- a/budget-macros/tests/ui/fail_return_in_macro.stderr
+++ b/budget-macros/tests/ui/fail_return_in_macro.stderr
@@ -1,0 +1,5 @@
+error: `return` inside a macro invocation is not supported by the budget macros: the assertion cannot be injected into macro tokens, so it would be skipped silently. Move the `return` out of the macro invocation, or end the test with a tail expression instead. (If this `return` belongs to a closure passed to the macro, lift the closure into a `let` binding before the macro call.)
+  --> tests/ui/fail_return_in_macro.rs:17:9
+   |
+17 |         return Err(TestError)
+   |         ^^^^^^

--- a/budget-macros/tests/ui/pass/pass_early_return.rs
+++ b/budget-macros/tests/ui/pass/pass_early_return.rs
@@ -1,0 +1,97 @@
+//! Early `return`s: every path that leaves the test runs the assertion, so a
+//! budget regression can no longer hide behind an early exit.
+
+#[path = "../support/mock_env.rs"]
+mod mock_env;
+
+use budget_macros::budget_cpu_lt;
+use mock_env::{budget_panic, Env};
+
+#[derive(Debug, PartialEq)]
+struct TestError;
+
+#[budget_cpu_lt(1_000)]
+fn early_return_unit(exit_early: bool) {
+    let env = Env::new(1_001, 0);
+    if exit_early {
+        return;
+    }
+    assert!(env.cost_estimate().budget().cpu_instruction_cost() > 0);
+}
+
+#[budget_cpu_lt(1_000)]
+fn early_return_value(exit_early: bool) -> Result<&'static str, TestError> {
+    let env = Env::new(1_001, 0);
+    if exit_early {
+        return Ok("early");
+    }
+    Ok("late")
+}
+
+#[budget_cpu_lt(2_000)]
+fn early_return_under_limit(exit_early: bool) -> Result<&'static str, TestError> {
+    let env = Env::new(1_001, 0);
+    if exit_early {
+        return Ok("early");
+    }
+    Ok("late")
+}
+
+/// A `return` nested in a loop inside a match arm is still a test exit.
+#[budget_cpu_lt(1_000)]
+fn early_return_nested(limit: u32) -> u32 {
+    let env = Env::new(1_001, 0);
+    match limit {
+        0 => 0,
+        n => {
+            for i in 0..n {
+                if i == 2 {
+                    return i;
+                }
+            }
+            n
+        }
+    }
+}
+
+/// A `return` inside a closure exits the closure, not the test, so it must not
+/// pick up the assertion.
+#[budget_cpu_lt(1_000)]
+fn return_inside_closure() -> u64 {
+    let env = Env::new(999, 0);
+    let first_big = |values: &[u64]| -> u64 {
+        for &value in values {
+            if value > 2 {
+                return value;
+            }
+        }
+        0
+    };
+    first_big(&[1, 2, 5])
+}
+
+fn main() {
+    assert_eq!(early_return_under_limit(true), Ok("early"));
+    assert_eq!(early_return_under_limit(false), Ok("late"));
+    assert_eq!(return_inside_closure(), 5);
+
+    for (name, message) in [
+        ("early_return_unit", budget_panic(|| early_return_unit(true))),
+        (
+            "early_return_value",
+            budget_panic(|| early_return_value(true)),
+        ),
+        (
+            "early_return_nested",
+            budget_panic(|| early_return_nested(5)),
+        ),
+    ] {
+        let message = message.unwrap_or_else(|| {
+            panic!("{name}: the budget assertion should have failed on the early return")
+        });
+        assert!(
+            message.contains("CPU instruction cost 1001 exceeded limit 1000"),
+            "{name}: unexpected panic message: {message}"
+        );
+    }
+}

--- a/budget-macros/tests/ui/pass/pass_env_var_limit.rs
+++ b/budget-macros/tests/ui/pass/pass_env_var_limit.rs
@@ -1,0 +1,78 @@
+//! The `env = "VAR"` limit form keeps working, including for bodies that set the
+//! variable themselves (the limit is still read after the body has run) and for
+//! bodies that end in a trailing expression.
+
+#[path = "../support/mock_env.rs"]
+mod mock_env;
+
+use budget_macros::{budget_cpu_lt, budget_mem_lt};
+use mock_env::{budget_panic, Env};
+
+#[derive(Debug, PartialEq)]
+struct TestError;
+
+#[budget_cpu_lt(env = "UI_TEST_MAX_CPU")]
+fn limit_set_inside_body() -> Result<(), TestError> {
+    std::env::set_var("UI_TEST_MAX_CPU", "1000");
+    let env = Env::new(999, 0);
+    Ok(())
+}
+
+#[budget_cpu_lt(env = "UI_TEST_MAX_CPU_EXCEEDED")]
+fn limit_exceeded() {
+    std::env::set_var("UI_TEST_MAX_CPU_EXCEEDED", "1000");
+    let env = Env::new(1_001, 0);
+}
+
+/// The macro injects a `budget_env_resolve` helper that the test body may shadow
+/// (`amm-pool-contract`'s `env = "VAR"` tests do exactly this). The limit is
+/// resolved in body scope at the exit point, so the shadowing binding wins: an
+/// unset `UI_TEST_SHADOWED` would otherwise mean "no limit" and never panic.
+#[budget_cpu_lt(env = "UI_TEST_SHADOWED")]
+fn limit_from_shadowed_resolver() -> Result<(), TestError> {
+    let budget_env_resolve = |_var: &str| -> Option<String> { Some("1000".to_string()) };
+    let env = Env::new(1_001, 0);
+    Ok(())
+}
+
+/// Same, reached through an early `return` instead of the trailing expression.
+#[budget_cpu_lt(env = "UI_TEST_SHADOWED")]
+fn shadowed_resolver_on_early_return(exit_early: bool) {
+    let budget_env_resolve = |_var: &str| -> Option<String> { Some("1000".to_string()) };
+    let env = Env::new(1_001, 0);
+    if exit_early {
+        return;
+    }
+}
+
+/// An unset (or unparsable) variable falls back to `u64::MAX`, i.e. no limit.
+#[budget_mem_lt(env = "UI_TEST_MAX_MEM_UNSET")]
+fn limit_missing_falls_back() -> Result<u64, TestError> {
+    std::env::remove_var("UI_TEST_MAX_MEM_UNSET");
+    let env = Env::new(0, u64::MAX - 1);
+    Ok(env.cost_estimate().budget().memory_bytes_cost())
+}
+
+fn main() {
+    assert_eq!(limit_set_inside_body(), Ok(()));
+    assert_eq!(limit_missing_falls_back(), Ok(u64::MAX - 1));
+
+    for (name, message) in [
+        ("limit_exceeded", budget_panic(limit_exceeded)),
+        (
+            "limit_from_shadowed_resolver",
+            budget_panic(|| limit_from_shadowed_resolver().map(|_| ())),
+        ),
+        (
+            "shadowed_resolver_on_early_return",
+            budget_panic(|| shadowed_resolver_on_early_return(true)),
+        ),
+    ] {
+        let message = message
+            .unwrap_or_else(|| panic!("{name}: the budget assertion should have failed"));
+        assert!(
+            message.contains("CPU instruction cost 1001 exceeded limit 1000"),
+            "{name}: unexpected panic message: {message}"
+        );
+    }
+}

--- a/budget-macros/tests/ui/pass/pass_mem.rs
+++ b/budget-macros/tests/ui/pass/pass_mem.rs
@@ -1,0 +1,43 @@
+//! `#[budget_mem_lt]` shares the expansion with `#[budget_cpu_lt]`, so it gets
+//! the same body shapes: unit, trailing expression, and early return.
+
+#[path = "../support/mock_env.rs"]
+mod mock_env;
+
+use budget_macros::budget_mem_lt;
+use mock_env::{budget_panic, Env};
+
+#[derive(Debug, PartialEq)]
+struct TestError;
+
+#[budget_mem_lt(4_096)]
+fn unit_body() {
+    let env = Env::new(0, 2_048);
+}
+
+#[budget_mem_lt(4_096)]
+fn result_body() -> Result<u64, TestError> {
+    let env = Env::new(0, 2_048);
+    Ok(env.cost_estimate().budget().memory_bytes_cost())
+}
+
+#[budget_mem_lt(4_096)]
+fn early_return_body(exit_early: bool) -> Result<(), TestError> {
+    let env = Env::new(0, 8_192);
+    if exit_early {
+        return Ok(());
+    }
+    Ok(())
+}
+
+fn main() {
+    unit_body();
+    assert_eq!(result_body(), Ok(2_048));
+
+    let message =
+        budget_panic(|| early_return_body(true)).expect("the budget assertion should have failed");
+    assert!(
+        message.contains("Memory bytes cost 8192 exceeded limit 4096"),
+        "unexpected panic message: {message}"
+    );
+}

--- a/budget-macros/tests/ui/pass/pass_result.rs
+++ b/budget-macros/tests/ui/pass/pass_result.rs
@@ -1,0 +1,75 @@
+//! `Result`-returning bodies: the trailing expression stays the function's
+//! value and the assertion runs after it is evaluated.
+
+#[path = "../support/mock_env.rs"]
+mod mock_env;
+
+use budget_macros::budget_cpu_lt;
+use mock_env::{budget_panic, Env};
+
+#[derive(Debug, PartialEq)]
+struct TestError(&'static str);
+
+fn doubled(n: u64) -> Result<u64, TestError> {
+    Ok(n * 2)
+}
+
+fn failing() -> Result<u64, TestError> {
+    Err(TestError("boom"))
+}
+
+#[budget_cpu_lt(1_000)]
+fn tail_ok() -> Result<(), TestError> {
+    let env = Env::new(999, 0);
+    Ok(())
+}
+
+#[budget_cpu_lt(1_000)]
+fn tail_ok_over_limit() -> Result<(), TestError> {
+    let env = Env::new(1_001, 0);
+    Ok(())
+}
+
+/// `?` keeps working: it borrows nothing from the assertion and the value it
+/// produces is still available to the trailing expression.
+#[budget_cpu_lt(1_000)]
+fn question_mark() -> Result<u64, TestError> {
+    let env = Env::new(999, 0);
+    let value = doubled(21)?;
+    Ok(value)
+}
+
+/// A propagating `?` leaves before the assertion, but the test fails on the
+/// returned error anyway.
+#[budget_cpu_lt(1)]
+fn question_mark_propagates() -> Result<u64, TestError> {
+    let env = Env::new(u64::MAX, 0);
+    let value = failing()?;
+    Ok(value)
+}
+
+/// The trailing expression can be block-like and can own locals the assertion
+/// does not touch.
+#[budget_cpu_lt(1_000)]
+fn tail_match() -> Result<String, TestError> {
+    let env = Env::new(999, 0);
+    let owned = String::from("pool");
+    match owned.len() {
+        4 => Ok(owned),
+        _ => Err(TestError("unexpected length")),
+    }
+}
+
+fn main() {
+    assert_eq!(tail_ok(), Ok(()));
+    assert_eq!(question_mark(), Ok(42));
+    assert_eq!(question_mark_propagates(), Err(TestError("boom")));
+    assert_eq!(tail_match(), Ok(String::from("pool")));
+
+    let message =
+        budget_panic(tail_ok_over_limit).expect("the budget assertion should have failed");
+    assert!(
+        message.contains("CPU instruction cost 1001 exceeded limit 1000"),
+        "unexpected panic message: {message}"
+    );
+}

--- a/budget-macros/tests/ui/pass/pass_unit.rs
+++ b/budget-macros/tests/ui/pass/pass_unit.rs
@@ -1,0 +1,40 @@
+//! Plain `()` bodies: the assertion runs after the last statement, unchanged
+//! from the original macro behavior.
+
+#[path = "../support/mock_env.rs"]
+mod mock_env;
+
+use budget_macros::budget_cpu_lt;
+use mock_env::{budget_panic, Env};
+
+#[budget_cpu_lt(1_000)]
+fn under_limit() {
+    let env = Env::new(999, 0);
+    let _ = env.cost_estimate().budget().cpu_instruction_cost();
+}
+
+#[budget_cpu_lt(1_000)]
+fn over_limit() {
+    let env = Env::new(1_000, 0);
+}
+
+#[budget_cpu_lt(1_000)]
+fn statement_ends_with_semicolon() {
+    let env = Env::new(500, 0);
+    let mut total = 0;
+    for i in 0..3 {
+        total += i;
+    }
+    assert_eq!(total, 3);
+}
+
+fn main() {
+    under_limit();
+    statement_ends_with_semicolon();
+
+    let message = budget_panic(over_limit).expect("the budget assertion should have failed");
+    assert!(
+        message.contains("CPU instruction cost 1000 exceeded limit 1000"),
+        "unexpected panic message: {message}"
+    );
+}

--- a/budget-macros/tests/ui/pass/pass_write_bytes.rs
+++ b/budget-macros/tests/ui/pass/pass_write_bytes.rs
@@ -1,0 +1,44 @@
+//! `#[budget_write_bytes_lt]` is instrumented by the same shared helper, so it
+//! supports the same body shapes: unit, trailing expression, and early return.
+//! It reports `memory_bytes_cost()` as its write-bytes proxy.
+
+#[path = "../support/mock_env.rs"]
+mod mock_env;
+
+use budget_macros::budget_write_bytes_lt;
+use mock_env::{budget_panic, Env};
+
+#[derive(Debug, PartialEq)]
+struct TestError;
+
+#[budget_write_bytes_lt(4_096)]
+fn unit_body() {
+    let env = Env::new(0, 2_048);
+}
+
+#[budget_write_bytes_lt(4_096)]
+fn result_body() -> Result<u64, TestError> {
+    let env = Env::new(0, 2_048);
+    Ok(env.cost_estimate().budget().memory_bytes_cost())
+}
+
+#[budget_write_bytes_lt(4_096)]
+fn early_return_body(exit_early: bool) -> Result<(), TestError> {
+    let env = Env::new(0, 8_192);
+    if exit_early {
+        return Ok(());
+    }
+    Ok(())
+}
+
+fn main() {
+    unit_body();
+    assert_eq!(result_body(), Ok(2_048));
+
+    let message =
+        budget_panic(|| early_return_body(true)).expect("the budget assertion should have failed");
+    assert!(
+        message.contains("Write bytes cost (memory proxy) 8192 exceeded limit 4096"),
+        "unexpected panic message: {message}"
+    );
+}

--- a/budget-macros/tests/ui/support/mock_env.rs
+++ b/budget-macros/tests/ui/support/mock_env.rs
@@ -1,0 +1,66 @@
+//! Minimal stand-in for `soroban_sdk::Env` for the UI tests.
+//!
+//! The macros only emit `env.cost_estimate().budget().<metric>()`, so the UI
+//! tests can exercise every body shape against this mock instead of pulling in
+//! the SDK and compiling a contract. Reported costs are fixed per instance so a
+//! test can decide up front whether the injected assertion should pass or panic.
+
+#![allow(dead_code)]
+
+pub struct Env {
+    cpu: u64,
+    mem: u64,
+}
+
+pub struct CostEstimate<'a> {
+    env: &'a Env,
+}
+
+pub struct Budget<'a> {
+    env: &'a Env,
+}
+
+impl Env {
+    pub fn new(cpu: u64, mem: u64) -> Self {
+        Env { cpu, mem }
+    }
+
+    pub fn cost_estimate(&self) -> CostEstimate<'_> {
+        CostEstimate { env: self }
+    }
+}
+
+impl<'a> CostEstimate<'a> {
+    pub fn budget(&self) -> Budget<'a> {
+        Budget { env: self.env }
+    }
+}
+
+impl Budget<'_> {
+    pub fn cpu_instruction_cost(&self) -> u64 {
+        self.env.cpu
+    }
+
+    pub fn memory_bytes_cost(&self) -> u64 {
+        self.env.mem
+    }
+}
+
+/// Runs `f`, returning the budget assertion's panic message if it panicked.
+pub fn budget_panic<F: FnOnce() -> R + std::panic::UnwindSafe, R>(f: F) -> Option<String> {
+    let previous_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(|_| {}));
+    let result = std::panic::catch_unwind(f);
+    std::panic::set_hook(previous_hook);
+
+    match result {
+        Ok(_) => None,
+        Err(payload) => Some(
+            payload
+                .downcast_ref::<String>()
+                .cloned()
+                .or_else(|| payload.downcast_ref::<&str>().map(|s| s.to_string()))
+                .unwrap_or_default(),
+        ),
+    }
+}

--- a/cargo-budget-report/src/module_8.rs
+++ b/cargo-budget-report/src/module_8.rs
@@ -450,7 +450,7 @@ mod off_by_one_and_zero_length_tests {
     fn scaffold_init_creates_file_when_not_exists() {
         let (_tmp, prev) = isolate_temp_dir();
 
-        let result = scaffold_init(false);
+        let result = scaffold_init(false, true);
         assert!(result.is_ok());
         assert!(
             std::path::Path::new("budget.toml").exists(),
@@ -472,7 +472,7 @@ mod off_by_one_and_zero_length_tests {
         let (_tmp, prev) = isolate_temp_dir();
         std::fs::write("budget.toml", "existing data").unwrap();
 
-        let result = scaffold_init(false);
+        let result = scaffold_init(false, true);
         assert!(result.is_err());
         let err = format!("{:#}", result.as_ref().unwrap_err());
         assert!(
@@ -495,7 +495,7 @@ mod off_by_one_and_zero_length_tests {
         let (_tmp, prev) = isolate_temp_dir();
         std::fs::write("budget.toml", "existing data").unwrap();
 
-        let result = scaffold_init(true);
+        let result = scaffold_init(true, true);
         assert!(result.is_ok());
 
         let content = std::fs::read_to_string("budget.toml").unwrap();

--- a/docs/src/developer_guide.md
+++ b/docs/src/developer_guide.md
@@ -13,7 +13,7 @@ This guide is for developers modifying or extending `soroban-budget-assert` itse
 
 | Crate | Role |
 |---|---|
-| `budget-macros` | Proc-macro crate. `budget_cpu_lt` / `budget_mem_lt` rewrite a test function's block to append a budget assertion against its `env` variable. |
+| `budget-macros` | Proc-macro crate. `budget_cpu_lt` / `budget_mem_lt` / `budget_lt` / `budget_write_bytes_lt` rewrite a test function's block so a budget assertion against its `env` variable runs on every exit path. They all go through `instrument_exit_paths()`; `ReturnRewriter` handles the `return` cases. |
 | `cargo-budget-report` | The CLI (`cargo budget-report` subcommand). Uses `cargo_metadata` for workspace discovery, `wasmparser` for export scanning, shells out to `stellar` for deploy/invoke/XDR decode, and `tabled`/`serde_json` for output. |
 | `amm-pool-contract` | Reference contract (`do_expensive_work`) plus the integration tests that double as the research measurements. |
 
@@ -28,13 +28,17 @@ cargo build -p amm-pool-contract --release --target wasm32-unknown-unknown
 cargo test
 ```
 
-`amm-pool-contract/tests/budget_test.rs` contains six tests:
+`amm-pool-contract/tests/budget_test.rs` covers the macros against the real SDK `Env`:
 
 - `test_budget_raw_rust` / `test_budget_wasm` — print raw-Rust vs. WASM local cost estimates (the source of the measured-gap figures in Mechanics).
 - `test_budget_macro_gated` — a passing assertion at the 950,000 CPU limit.
 - `test_budget_macro_deliberate_regression` — asserts an intentionally low limit (600,000) and expects the macro's panic, proving the gate fires.
 - `test_budget_macro_dynamic_env` — asserts a CPU limit read from the `TEST_MAX_CPU` environment variable.
 - `test_budget_macro_dynamic_env_fallback` — verifies the fallback behaviour: when the env var is unset, the limit defaults to `u64::MAX` and the assertion passes unconditionally.
+- `test_budget_macro_json_config_*` — the `config = "key"` limit form read from `budget.json`.
+- `test_budget_macro_result_returning` / `..._regression` / `test_budget_macro_early_return_still_asserts` — the `Result`-returning and early-`return` body shapes.
+
+`budget-macros/tests/ui.rs` is a `trybuild` suite that needs no WASM and no SDK. `tests/ui/*.rs` must fail to compile, with the diagnostic pinned in the matching `.stderr` — regenerate those with `TRYBUILD=overwrite cargo test -p budget-macros`. `tests/ui/pass/*.rs` must compile *and run*: each one exercises a test-body shape against the mock `env` in `tests/ui/support/mock_env.rs` (fixed costs) and asserts which cost and limit the injected check reports, so a body shape that silently stops being checked fails there.
 
 To exercise the CLI end-to-end against testnet (requires the funded `alice` identity):
 
@@ -44,7 +48,7 @@ cargo run -p cargo-budget-report -- budget-report
 
 ## Extending
 
-- **New assertion metrics** — follow the pattern in `budget-macros/src/lib.rs`: parse the limit literal, append a check on `env.cost_estimate().budget()`, keep the failure message explicit. Add a passing test and a `#[should_panic]` regression test in `amm-pool-contract`.
+- **New assertion metrics** — follow the pattern in `budget-macros/src/lib.rs`: build the metric's `assert!` with its accessor on `env.cost_estimate().budget()`, then hand the function and that assertion to `instrument_exit_paths()` so the check reaches every exit path. Keep the failure message explicit. Add a passing test and a `#[should_panic]` regression test in `amm-pool-contract`, plus a `tests/ui/pass/` UI case.
 - **CLI changes** — no panics; return `anyhow::Result` with `.context()` on every external call (network, `stellar` invocations, file I/O). Any new output must also work under `--json`.
 - **Docs** — this site is GitBook, synced from the repository via Git Sync (`.gitbook.yaml` points at `docs/src`). Edits merged to `main` publish automatically; no CI step is involved. Add pages to `docs/src/SUMMARY.md` (GitBook's table of contents). GitBook-specific blocks (`{% hint %}`, `{% code title %}`) are available in any page.
 

--- a/docs/src/mechanics.md
+++ b/docs/src/mechanics.md
@@ -17,17 +17,24 @@ Two conclusions drive the tool's design:
 
 ## Tier A: Local fast fail (`budget-macros`)
 
-Two attribute macros gate tests on local cost estimates. Each rewrites the test function's body: the original statements run first, then the macro appends a cost check against the test's local `env` variable.
+Two attribute macros gate tests on local cost estimates. Each rewrites the test function's body so a cost check against the test's local `env` variable runs on every path that leaves the test.
 
 ### `#[budget_cpu_lt(N)]` — CPU instruction assertion
 
-Appends the equivalent of:
+Injects the equivalent of:
 
-{% code title="appended by #[budget_cpu_lt(N)]" %}
+{% code title="injected by #[budget_cpu_lt(N)]" %}
 ```rust
-let budget = env.cost_estimate().budget();
-let cpu_cost = budget.cpu_instruction_cost();
-assert!(cpu_cost < N, "CPU instruction cost {} exceeded limit {} - ...", cpu_cost, N);
+// ... original statements, with each `return e` rewritten to
+//     `return { let v = e; <check>; v }` ...
+
+let __budget_value = /* original trailing expression, if any */;
+{
+    let budget = env.cost_estimate().budget();
+    let cpu_cost = budget.cpu_instruction_cost();
+    assert!(cpu_cost < N, "CPU instruction cost {} exceeded limit {} - ...", cpu_cost, N);
+}
+__budget_value
 ```
 {% endcode %}
 
@@ -35,13 +42,15 @@ assert!(cpu_cost < N, "CPU instruction cost {} exceeded limit {} - ...", cpu_cos
 
 Same shape, checks `budget.memory_bytes_cost()`:
 
-{% code title="appended by #[budget_mem_lt(N)]" %}
+{% code title="injected by #[budget_mem_lt(N)]" %}
 ```rust
 let budget = env.cost_estimate().budget();
 let mem_cost = budget.memory_bytes_cost();
 assert!(mem_cost < N, "Memory bytes cost {} exceeded limit {} - ...", mem_cost, N);
 ```
 {% endcode %}
+
+Binding the trailing expression keeps it as the function's value, so `fn test() -> Result<(), Error>` bodies ending in `Ok(())` compile; rewriting `return` keeps an early exit from skipping the check. The check stays inside the body's scope, so the limit expression still resolves against the body's own bindings. Two paths out of the body are not instrumented: a `?` that propagates an error (the test already fails on that error) and a `return` produced by another macro's expansion. A `return` written directly in macro invocation tokens is a compile error rather than a silent skip — see the [Reference](reference.md).
 
 Both assertions are strict (`<`). If the local estimate reaches the limit, the test panics and `cargo test` fails, which blocks CI. This tier is fast (no network) and deterministic, so it is safe to run on every push and pull request.
 
@@ -53,7 +62,7 @@ Either macro can read its limit from an environment variable at test time instea
 #[budget_cpu_lt(env = "MY_CPU_LIMIT")]
 ```
 
-When the variable is unset or not a valid `u64`, the limit defaults to `u64::MAX`, making the assertion pass unconditionally. This lets you raise or disable limits without recompiling — useful for CI matrix builds where different runners have different budgets.
+When the variable is unset, the limit defaults to `u64::MAX`, making the assertion pass unconditionally; a set-but-unparsable value panics. This lets you raise or disable limits without recompiling — useful for CI matrix builds where different runners have different budgets.
 
 ## Tier B: Network simulation (`cargo-budget-report`)
 

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -4,6 +4,36 @@
 
 Both macros are attribute macros for test functions. They require a local variable named `env` (a `soroban_sdk::Env`) in the function body — the injected check reads `env.cost_estimate().budget()` after the original test statements run.
 
+The check runs on every path that leaves the test, so all of these body shapes work:
+
+```rust
+#[test]
+#[budget_cpu_lt(850000)]
+fn unit_test() {
+    let env = Env::default();
+    // ... the check runs after the last statement ...
+}
+
+#[test]
+#[budget_cpu_lt(850000)]
+fn result_test() -> Result<(), Box<dyn std::error::Error>> {
+    let env = Env::default();
+    let wasm = std::fs::read("../target/wasm32-unknown-unknown/release/my_contract.wasm")?;
+    // ... the check runs after `Ok(())` is evaluated, and it is still the test's value ...
+    Ok(())
+}
+
+#[test]
+#[budget_cpu_lt(850000)]
+fn early_return_test() {
+    let env = Env::default();
+    if std::env::var("SKIP_SLOW_PATH").is_ok() {
+        return; // the check runs here too
+    }
+    // ...
+}
+```
+
 ### `#[budget_cpu_lt(N)]`
 
 Asserts that the CPU instruction cost measured by the test's `env` is strictly less than `N`.
@@ -72,7 +102,7 @@ If the file does not exist, the key is missing, or the value is not a valid `u64
 
 On failure the test panics with:
 ```
-CPU instruction cost {actual} exceeded limit {N} - local estimate, underestimates real network cost
+CPU instruction cost {actual} exceeded limit {N} - local estimate, real network cost may differ significantly in either direction
 ```
 
 ### `#[budget_mem_lt(N)]`
@@ -117,7 +147,7 @@ fn test_memory_with_json_config() {
 
 Failure message format:
 ```
-Memory bytes cost {actual} exceeded limit {N} - local estimate, underestimates real network cost
+Memory bytes cost {actual} exceeded limit {N} - local estimate, real network cost may differ significantly in either direction
 ```
 
 ```rust
@@ -144,6 +174,9 @@ fn test_memory_budget() {
 
 {% hint style="warning" %}
 - The variable must be named `env`. The macro resolves the identifier by name.
+- A `?` that propagates an error leaves the test before the check runs. The test still fails on the returned error, so a regression cannot pass unnoticed — but the budget number is not measured on that path.
+- A `return` that comes from *another* macro's expansion (e.g. an `ensure!`/`bail!`-style macro) is invisible to the rewrite and skips the check. A `return` written directly inside macro invocation tokens is rejected with a compile error instead of being skipped silently; move it out of the macro call. This applies to every budget macro.
+- `return` inside a closure or `async` block in the test body is left alone — it exits that body, not the test.
 - Run the contract as WASM (`env.register_contract_wasm`) inside the test, not as raw Rust — raw Rust estimates ran ~81% under real network cost in our measurements and make the assertion meaningless.
 - Call `env.cost_estimate().budget().reset_unlimited()` before invoking the contract so measurement isn't cut short by the default test budget.
 - The macro checks the *local* estimate, which can sit above or below the real network cost depending on the build profile. Set `N` a few percent above the measured local number to catch regressions, and use `cargo budget-report` for the network ground truth (see the End-User Guide).


### PR DESCRIPTION
Closes #6

Rebased onto current `main` (`ac40ed0`). Conflicts resolved against upstream's versions; see *Rebase notes*.

## Problem

The budget macros re-emitted the test body's statements and appended the assertion after them:

```rust
let new_block = quote! {{
    {{
        #(#stmts)*
        let budget = env.cost_estimate().budget();
        assert!(...);
    }}
}};
```

That broke two legitimate test shapes:

1. **`Result`-returning tests** — statements landed *after* the trailing expression, so `fn test() -> Result<(), Error>` ending in `Ok(())` failed to compile (`expected ;`).
2. **Early returns** — a `return` left the function before the appended assertion, so the budget check silently never ran and the test passed regardless of cost.

## Fix

The check is now injected on **every path out of the test**, through one shared `instrument_exit_paths()` used by `generate_budget_assert` (`budget_cpu_lt`, `budget_mem_lt`, `budget_lt`) *and* by `budget_write_bytes_lt`:

- A trailing expression is bound (`let __budget_value = <tail>;`), then the check runs, then the value is yielded — so it stays the function's value and `-> Result<_, _>` tests compile.
- `ReturnRewriter` (a `syn::visit_mut` pass) rewrites each `return e` to `return {{ let v = e; <check>; v }}`. Wrapping the block *inside* `return` keeps the expression's `!` type, so `return` in value position still type-checks, and evaluating `e` first means the returned value's own cost is counted. `return`s inside closures, `async` blocks, and nested items are left alone — they exit that body, not the test.

`budget_write_bytes_lt` had the same defect and now goes through the same helper, so all four macros behave consistently.

**Each metric's assertion is unchanged** — same `budget`/`cost`/`limit_u64` bindings, same strict `<`, same messages — and it still expands *inside the body's scope*. That last part matters here: the `env = "VAR"` tests shadow the injected `budget_env_resolve` helper in their own body. Hoisting the limit into a closure at the top of the body (or into the immediately-invoked closure the issue suggested) would have silently broken them — the shadowing binding would no longer win, an unset variable would mean "no limit", and those tests would still pass while checking nothing. Two UI cases (`limit_from_shadowed_resolver`, `shadowed_resolver_on_early_return`) fail loudly if that ever regresses.

For the same reason I did not use the immediately-invoked-closure approach from the issue: `env` is declared *inside* the test body, so it would no longer be reachable for `env.cost_estimate()` after the closure returned. Instrumenting the exit points keeps `env`, `?`, and the locals' move semantics exactly as the author wrote them.

Two paths remain uninstrumented, both documented in the Reference:

- A `?` that propagates an error exits before the check. The test still fails on that error, so a regression cannot pass unnoticed.
- A `return` produced by *another* macro's expansion (an `ensure!`/`bail!`-style macro) is invisible at attribute-expansion time. A `return` written directly in macro invocation tokens *is* detectable, and is now a compile error rather than a silent skip:

```
error: `return` inside a macro invocation is not supported by the budget macros: the assertion
       cannot be injected into macro tokens, so it would be skipped silently. Move the `return`
       out of the macro invocation, or end the test with a tail expression instead. ...
  --> tests/ui/fail_return_in_macro.rs:17:9
   |
17 |         return Err(TestError)
   |         ^^^^^^
```

The generated function also carries `#[allow(unreachable_code)]`, so a body ending in `return`/`panic!` does not turn the trailing check into a warning (which would break `-D warnings` downstream).

Unchanged: integer limits, `env = "VAR"` (including the `u64::MAX` fallback and the panic on an unparsable value), `config = "key"`, the strict `<` comparison, and every panic message.

## Tests

`budget-macros/tests/ui.rs` keeps your existing `compile_fail("tests/ui/*.rs")` glob and adds `t.pass("tests/ui/pass/*.rs")`. The pass cases live in their own directory precisely so they stay out of the compile-fail glob. They are compiled **and run** against a mock `env` (`tests/ui/support/mock_env.rs`) with fixed costs, so they assert which cost and limit the injected check actually reports, and they need neither the SDK nor a WASM build.

| Case | Covers |
|---|---|
| `pass/pass_unit.rs` | plain `()` body, under and over the limit |
| `pass/pass_result.rs` | `-> Result<_, _>` with `Ok(())` tail, `?`, propagating `?`, block-like tail owning a local |
| `pass/pass_early_return.rs` | early `return`, early `return <value>`, `return` nested in a loop in a match arm, `return` inside a closure (must *not* be instrumented) |
| `pass/pass_env_var_limit.rs` | `env = "VAR"` set inside the body, exceeded, unset fallback, and the shadowed-`budget_env_resolve` cases on both the tail and early-return paths |
| `pass/pass_mem.rs` | `#[budget_mem_lt]` across unit / `Result` / early-return bodies |
| `pass/pass_write_bytes.rs` | `#[budget_write_bytes_lt]` across the same three shapes |
| `fail_return_in_macro.rs` | `return` in macro tokens is a clear compile error |

Your five existing `.stderr` snapshots are **byte-for-byte unchanged**, i.e. this does not perturb the diagnostics they pin. I dropped my earlier `fail_bad_limit` case because `invalid_arg.rs` + `no_arg.rs` now cover it.

`amm-pool-contract/tests/budget_test.rs` adds the same shapes against the real `soroban_sdk::Env` via `setup_wasm`: a passing `Result`-returning test, a `Result`-returning regression that must panic (caught by hand, since `#[should_panic]` requires a test returning `()`), and an early-`return` test that must panic. The passing one uses a deliberately generous limit with a comment saying so — it pins the body shape, not a cost figure, so it will not need re-measuring when the WASM build changes.

All commands below ran on the repo's pinned toolchain (rustc 1.85.0), WASM built for `wasm32v1-none`.

### `cargo fmt --all -- --check`

```
$ cargo fmt --all -- --check
(no output)
```

### `cargo clippy --workspace --all-targets -- -D warnings`

```
$ cargo clippy --workspace --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 22.97s
(no warnings; exit 0)
```

### `cargo test --workspace`

```
   Running tests/budget_test.rs
running 32 tests
test result: ok. 32 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.89s

   Running tests/cross_contract_test.rs
running 4 tests
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 5.05s

   Running tests/ui.rs
running 1 test
test tests/ui/fail_return_in_macro.rs [should fail to compile] ... ok
test tests/ui/invalid_arg.rs [should fail to compile] ... ok
test tests/ui/missing_env.rs [should fail to compile] ... ok
test tests/ui/missing_env_mem.rs [should fail to compile] ... ok
test tests/ui/no_arg.rs [should fail to compile] ... ok
test tests/ui/on_struct.rs [should fail to compile] ... ok
test tests/ui/pass/pass_early_return.rs [should pass] ... ok
test tests/ui/pass/pass_env_var_limit.rs [should pass] ... ok
test tests/ui/pass/pass_mem.rs [should pass] ... ok
test tests/ui/pass/pass_result.rs [should pass] ... ok
test tests/ui/pass/pass_unit.rs [should pass] ... ok
test tests/ui/pass/pass_write_bytes.rs [should pass] ... ok
test ui_tests ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 31.97s

   Running unittests src/main.rs (cargo-budget-report)
running 114 tests
test result: ok. 114 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.20s
```

One note on that last line: under the default parallel runner, `module_8::…::scaffold_init_creates_file_when_not_exists` fails intermittently. The three `scaffold_init` tests each `set_current_dir` the whole process, so one test can chdir out from under another and read the repo's own `budget.toml` instead of the temp one. With `--test-threads=1` all 114 pass, as above. Pre-existing and unrelated to this PR — worth a follow-up to make those tests not mutate process CWD.

## Rebase notes

- `budget-macros/src/lib.rs` — took `main`'s version wholesale (`BudgetSpec`, the `config = "key"` handling, the rustdocs from #220, the `into_compile_error` parse handling from #221) and re-applied only the exit-path instrumentation, factored into `instrument_exit_paths()` so `budget_write_bytes_lt` shares it. Also updated the rustdocs that still said the macro "appends" the check.
- `budget-macros/tests/ui.rs` — this was the earlier CI failure: your new suite globs `compile_fail("tests/ui/*.rs")`, which swallowed my `pass_*.rs` files ("Expected test case to fail to compile, but it succeeded"). Mine now live in `tests/ui/pass/`.
- `amm-pool-contract/tests/budget_test.rs` — my three tests were rewritten for `ConstantProductPool` / `setup_wasm` and now sit after your write-bytes fixtures.
- Docs re-applied onto the restructured sections in `mechanics.md` / `developer_guide.md` / `reference.md`.
- `test_snapshots/*.json` are not committed: my locally built WASM hashes differ from the recorded ones, so committing them would be pure churn. Running the suite regenerates them.

### Two fixes needed to make the pipeline green, both already failing on `main`

- `cargo-budget-report/src/module_8.rs` — `scaffold_init` gained a `quiet` parameter in #261 but three test call sites still passed one argument, so `cargo test --workspace` did not compile (`error[E0061]` ×3). Passed `quiet = true` in the tests; `quiet` only gates an `eprintln!`, never the file write.
- `budget-macros/src/lib.rs` — `budget_mem_lt`'s rustdoc block sat above `budget_write_bytes_lt` with a blank line between them, which `-D warnings` rejects (`clippy::empty_line_after_doc_comments`), so Code Quality failed before reaching anything else. Moved the block onto the function it documents. Happy to split either of these out if you'd rather take them separately.

### `budget-check` cannot pass on any PR right now

`.github/workflows/budget.yml` is invalid YAML on `main`, so the workflow fails immediately with "This run likely failed because of a workflow file issue" and never reports — the same failure appears on `main`'s own pushes. Line 84 lost its indentation in the artifact refactor:

```yaml
    - name: Download Budget Report
      uses: actions/download-artifact@v4
      with:
name: budget-report          # <-- must be indented under `with:`
```

It needs to be:

```yaml
    - name: Download Budget Report
      uses: actions/download-artifact@v4
      with:
        name: budget-report
```

I can't include that fix here — pushing workflow changes needs a token scope I don't have on this fork — so it needs a commit on `main` (or a maintainer push to this branch).
