### PR TITLE
docs: publish Mermaid system architecture diagrams for GitBook

### DIFF
--- a/architecture/README.md
+++ b/architecture/README.md
@@ -1,0 +1,120 @@
+# Architecture Diagrams
+
+Visual reference for the two primary subsystems in `soroban-budget-assert`.
+Both diagrams are authored in [Mermaid](https://mermaid.js.org/) and render
+natively on GitHub and GitBook.
+
+---
+
+## Diagram 1 — `cargo-budget-report` Pipeline
+
+Shows the end-to-end lifecycle from the developer running `cargo budget-report`
+through WASM compilation, export discovery, RPC simulation, metric extraction,
+and final report generation. The `--check` path is highlighted to show how CI
+enforcement works.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Dev as Developer
+    participant CLI as cargo budget-report
+    participant Cargo as Cargo / rustc
+    participant WASM as WASM Binary
+    participant Parser as WASM Parser
+    participant Stellar as Stellar CLI
+    participant RPC as Soroban RPC
+    participant Report as Budget Report
+
+    Dev->>CLI: cargo budget-report [--check] [--json]
+    CLI->>Cargo: cargo build -p <contract> --release\n--target wasm32-unknown-unknown
+    Cargo-->>WASM: amm_pool_contract.wasm (cdylib)
+
+    CLI->>Parser: wasmparser: scan exports
+    Parser-->>CLI: exported function names list
+
+    CLI->>CLI: Read budget.toml\n(network, source, per-function args/limits)
+
+    loop For each exported function in budget.toml
+        CLI->>Stellar: stellar contract invoke\n--function <fn> --args <args>
+        Stellar->>RPC: simulateTransaction (XDR)
+        RPC-->>Stellar: SimulateTransactionResponse\n(transactionData XDR)
+        Stellar-->>CLI: stdout JSON response
+
+        CLI->>CLI: Decode transactionData XDR\nExtract: CPU instructions,\nread bytes, write bytes
+
+        alt --check mode and limit configured
+            CLI->>CLI: Compare value vs cpu_limit /\nread_limit / write_limit
+            CLI-->>Report: PASS or FAIL per metric
+        else report-only mode
+            CLI-->>Report: Record value (no enforcement)
+        end
+    end
+
+    CLI->>Report: Render table (tabled) or\nemit JSON (--json flag)
+    Report-->>Dev: Console output +\ncurrent_report.json artifact
+
+    alt Any limit breached or simulation failed
+        CLI-->>Dev: exit code 1 (CI fails)
+    else All checks pass
+        CLI-->>Dev: exit code 0 (CI passes)
+    end
+```
+
+**Source file:** [`cargo-budget-report-pipeline.mmd`](./cargo-budget-report-pipeline.mmd)
+
+---
+
+## Diagram 2 — `#[budget_cpu_lt]` Macro Compile-Time Expansion
+
+Shows how the `budget_cpu_lt` procedural macro rewrites a test function at
+compile time. Covers both the static integer form (`#[budget_cpu_lt(N)]`) and
+the dynamic environment-variable form (`#[budget_cpu_lt(env = "VAR")]`), and
+traces the two runtime outcomes: passing within the limit and panicking on a
+regression.
+
+```mermaid
+graph TD
+    A["#[budget_cpu_lt(N)] or\n#[budget_cpu_lt(env = \"VAR\")]"]
+    A --> B[Proc-macro invoked at compile time\nby rustc]
+
+    B --> C{Parse attribute tokens}
+
+    C -->|Integer literal| D["BudgetLimit::Int(N)\nlimit_expr = quote! { N }"]
+    C -->|env = \"VAR\" syntax| E["BudgetLimit::EnvVar(VAR)\nlimit_expr = quote! {\n  match budget_env_resolve(VAR) { … }\n}"]
+
+    D --> F[Parse test fn body via syn::ItemFn]
+    E --> F
+
+    F --> G[Inject preamble into fn body:\nlet budget_env_resolve = |var| std::env::var(var).ok()]
+
+    G --> H[Append cost-check epilogue:\nlet budget = env.cost_estimate().budget();\nlet cpu_cost = budget.cpu_instruction_cost();\nlet limit_u64: u64 = limit_expr;\nassert!(cpu_cost < limit_u64, …)]
+
+    H --> I[Emit rewritten fn tokens\nback to rustc]
+
+    I --> J{Runtime: test executes}
+
+    J -->|cpu_cost < limit_u64| K["Test passes ✅"]
+    J -->|cpu_cost >= limit_u64| L["panic! with message:\n'CPU instruction cost N exceeded limit M\n- local estimate, real network cost\nmay differ significantly in either direction'"]
+
+    L --> M{#[should_panic] present?}
+    M -->|Yes — deliberate regression fixture| N["Test passes ✅\n(expected failure documented)"]
+    M -->|No — real regression| O["Test fails ❌\nCI exits non-zero"]
+
+    style A fill:#1e3a5f,color:#fff,stroke:#4a90d9
+    style K fill:#1a4731,color:#fff,stroke:#2d7a4f
+    style N fill:#1a4731,color:#fff,stroke:#2d7a4f
+    style O fill:#5c1a1a,color:#fff,stroke:#c0392b
+    style L fill:#5c1a1a,color:#fff,stroke:#c0392b
+```
+
+**Source file:** [`budget-cpu-lt-macro-expansion.mmd`](./budget-cpu-lt-macro-expansion.mmd)
+
+---
+
+## Files in this directory
+
+| File | Description |
+|------|-------------|
+| `cargo-budget-report-pipeline.mmd` | Diagram 1 — full `cargo budget-report` lifecycle |
+| `budget-cpu-lt-macro-expansion.mmd` | Diagram 2 — `#[budget_cpu_lt]` compile-time expansion |
+| `README.md` | This file — rendered entry point for GitHub and GitBook |

--- a/architecture/budget-cpu-lt-macro-expansion.mmd
+++ b/architecture/budget-cpu-lt-macro-expansion.mmd
@@ -1,0 +1,32 @@
+graph TD
+    A["#[budget_cpu_lt(N)] or\n#[budget_cpu_lt(env = \"VAR\")]"]
+    A --> B[Proc-macro invoked at compile time\nby rustc]
+
+    B --> C{Parse attribute tokens}
+
+    C -->|Integer literal| D["BudgetLimit::Int(N)\nlimit_expr = quote! { N }"]
+    C -->|env = \"VAR\" syntax| E["BudgetLimit::EnvVar(VAR)\nlimit_expr = quote! {\n  match budget_env_resolve(VAR) { … }\n}"]
+
+    D --> F[Parse test fn body via syn::ItemFn]
+    E --> F
+
+    F --> G[Inject preamble into fn body:\nlet budget_env_resolve = |var| std::env::var(var).ok()]
+
+    G --> H[Append cost-check epilogue:\nlet budget = env.cost_estimate().budget();\nlet cpu_cost = budget.cpu_instruction_cost();\nlet limit_u64: u64 = limit_expr;\nassert!(cpu_cost < limit_u64, …)]
+
+    H --> I[Emit rewritten fn tokens\nback to rustc]
+
+    I --> J{Runtime: test executes}
+
+    J -->|cpu_cost < limit_u64| K["Test passes ✅"]
+    J -->|cpu_cost >= limit_u64| L["panic! with message:\n'CPU instruction cost N exceeded limit M\n- local estimate, real network cost\nmay differ significantly in either direction'"]
+
+    L --> M{#[should_panic] present?}
+    M -->|Yes — deliberate regression fixture| N["Test passes ✅\n(expected failure documented)"]
+    M -->|No — real regression| O["Test fails ❌\nCI exits non-zero"]
+
+    style A fill:#1e3a5f,color:#fff,stroke:#4a90d9
+    style K fill:#1a4731,color:#fff,stroke:#2d7a4f
+    style N fill:#1a4731,color:#fff,stroke:#2d7a4f
+    style O fill:#5c1a1a,color:#fff,stroke:#c0392b
+    style L fill:#5c1a1a,color:#fff,stroke:#c0392b

--- a/architecture/cargo-budget-report-pipeline.mmd
+++ b/architecture/cargo-budget-report-pipeline.mmd
@@ -1,0 +1,44 @@
+sequenceDiagram
+    autonumber
+    participant Dev as Developer
+    participant CLI as cargo budget-report
+    participant Cargo as Cargo / rustc
+    participant WASM as WASM Binary
+    participant Parser as WASM Parser
+    participant Stellar as Stellar CLI
+    participant RPC as Soroban RPC
+    participant Report as Budget Report
+
+    Dev->>CLI: cargo budget-report [--check] [--json]
+    CLI->>Cargo: cargo build -p <contract> --release\n--target wasm32-unknown-unknown
+    Cargo-->>WASM: amm_pool_contract.wasm (cdylib)
+
+    CLI->>Parser: wasmparser: scan exports
+    Parser-->>CLI: exported function names list
+
+    CLI->>CLI: Read budget.toml\n(network, source, per-function args/limits)
+
+    loop For each exported function in budget.toml
+        CLI->>Stellar: stellar contract invoke\n--function <fn> --args <args>
+        Stellar->>RPC: simulateTransaction (XDR)
+        RPC-->>Stellar: SimulateTransactionResponse\n(transactionData XDR)
+        Stellar-->>CLI: stdout JSON response
+
+        CLI->>CLI: Decode transactionData XDR\nExtract: CPU instructions,\nread bytes, write bytes
+
+        alt --check mode and limit configured
+            CLI->>CLI: Compare value vs cpu_limit /\nread_limit / write_limit
+            CLI-->>Report: PASS or FAIL per metric
+        else report-only mode
+            CLI-->>Report: Record value (no enforcement)
+        end
+    end
+
+    CLI->>Report: Render table (tabled) or\nemit JSON (--json flag)
+    Report-->>Dev: Console output +\ncurrent_report.json artifact
+
+    alt Any limit breached or simulation failed
+        CLI-->>Dev: exit code 1 (CI fails)
+    else All checks pass
+        CLI-->>Dev: exit code 0 (CI passes)
+    end


### PR DESCRIPTION
## Description

Closes #53

This PR introduces improvements to the repository by focusing on publishing Mermaid system architecture diagrams for the live GitBook documentation site.

Implementing this helps stabilize the developer experience and ensures we maintain high documentation quality standards. It resolves a known gap in our tooling by providing clear visual aids that explain the magic under the hood, directly benefiting downstream users relying on this library for Soroban smart contract development.

## What was done

An `architecture/` directory was added containing three files:

**`cargo-budget-report-pipeline.mmd` — Diagram 1**
A `sequenceDiagram` covering the full end-to-end lifecycle of `cargo budget-report`:
- WASM compilation via Cargo/rustc (`cdylib` output)
- Export discovery via `wasmparser`
- Per-function invocation via Stellar CLI → Soroban RPC `simulateTransaction`
- `transactionData` XDR decoding and metric extraction (CPU instructions, read bytes, write bytes)
- `--check` enforcement path against `budget.toml` limits (PASS / FAIL per metric)
- Final report rendering as table or JSON, and CI exit-code semantics

**`budget-cpu-lt-macro-expansion.mmd` — Diagram 2**
A `graph TD` flowchart showing the compile-time expansion of the `#[budget_cpu_lt]` procedural macro:
- Attribute token parsing for the static integer form `#[budget_cpu_lt(N)]` and the env-var form `#[budget_cpu_lt(env = VAR)]`
- `syn`/`quote`-based fn body rewriting: preamble injection and cost-check epilogue
- Two runtime outcomes: passing within limit and panicking on regression
- The `#[should_panic]` deliberate-regression fixture path

**`architecture/README.md`**
Embeds both diagrams as fenced Mermaid code blocks so they render natively on GitHub and can be synced directly to GitBook. Includes a file index table.

## How it was tested

- Diagrams verified against the [Mermaid Live Editor](https://mermaid.live) for correct syntax and rendering
- Both `sequenceDiagram` and `graph TD` syntax confirmed compatible with GitHub and GitBook native rendering
- No Rust source changes — `cargo fmt`, `cargo clippy`, and `cargo test` are unaffected

## Closes

Closes #53