### PR TITLE
feat: support per-module budget limits

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -6,9 +6,11 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
-  Code_Quality:
-    name: Code Quality
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -16,9 +18,15 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
+
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
+
+      - name: Install System Dependencies
+        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config libudev-dev
+
       - name: Check formatting
         run: cargo fmt --all -- --check
+
       - name: Run Clippy
         run: cargo clippy --workspace --all-targets -- -D warnings


### PR DESCRIPTION
Closes #61 

## What changed
Adds support for setting budget limits scoped to a module (contract),
in addition to the existing per-function limits. This lets users cap
total budget for a group of functions without having to set and
maintain a limit on every individual entry.

- New `[module.<name>]` section in `budget.toml` for module-level
  limits
- Enforcement checks both module-level and function-level limits;
  a run fails if either is exceeded
- README/config template updated with a module-limit example

## Example
```toml
[module.payments]
cpu_limit = 5_000_000
mem_limit = 200_000

[functions.transfer]
module = "payments"
args = ["...]
```

## Testing
- [ ] Existing function-level-only configs still work unchanged (no regression)
- [ ] Module limit enforced when function total exceeds it
- [ ] Module limit not required — configs without `[module.*]` behave as before
- [ ] Full local test suite passes