### PR TITLE
test: add trybuild compile-fail tests for budget macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,6 +278,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+ "trybuild",
 ]
 
 [[package]]
@@ -334,7 +335,7 @@ dependencies = [
  "stellar-xdr",
  "tabled",
  "tempfile",
- "toml",
+ "toml 0.8.23",
  "wasmparser",
 ]
 
@@ -904,6 +905,12 @@ dependencies = [
  "libc",
  "r-efi",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "group"
@@ -1750,6 +1757,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2184,6 +2200,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-triple"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3a6bfce3d99adfa72d24750a61f782f3036a81e7f86d8841ee1326deaebd171"
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2194,6 +2216,15 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -2306,9 +2337,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_edit",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -2321,6 +2367,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2328,10 +2383,19 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap 2.14.0",
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -2339,6 +2403,12 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tower-service"
@@ -2370,6 +2440,21 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "trybuild"
+version = "1.0.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06649c6f63d86604ba0c8950d5a1829fc9a17afd70fc6629f481d75b6a624c78"
+dependencies = [
+ "glob",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "target-triple",
+ "termcolor",
+ "toml 1.1.3+spec-1.1.0",
+]
 
 [[package]]
 name = "typenum"
@@ -2564,6 +2649,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2790,6 +2884,12 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "winreg"

--- a/budget-macros/Cargo.toml
+++ b/budget-macros/Cargo.toml
@@ -14,3 +14,6 @@ proc-macro = true
 syn = { version = "2.0", features = ["full", "extra-traits"] }
 quote = "1.0"
 proc-macro2 = "1.0"
+
+[dev-dependencies]
+trybuild = "1.0"

--- a/budget-macros/src/lib.rs
+++ b/budget-macros/src/lib.rs
@@ -45,8 +45,14 @@ fn generate_budget_assert(
     let attr_tokens: proc_macro2::TokenStream = attr.into();
     let item_tokens: proc_macro2::TokenStream = item.into();
 
-    let limit = syn::parse2::<BudgetLimit>(attr_tokens.clone()).unwrap();
-    let mut input_fn = syn::parse2::<ItemFn>(item_tokens).unwrap();
+    let limit = match syn::parse2::<BudgetLimit>(attr_tokens.clone()) {
+        Ok(l) => l,
+        Err(e) => return TokenStream::from(e.into_compile_error()),
+    };
+    let mut input_fn = match syn::parse2::<ItemFn>(item_tokens) {
+        Ok(f) => f,
+        Err(e) => return TokenStream::from(e.into_compile_error()),
+    };
 
     let stmts = &input_fn.block.stmts;
 

--- a/budget-macros/tests/ui.rs
+++ b/budget-macros/tests/ui.rs
@@ -1,0 +1,5 @@
+#[test]
+fn ui_tests() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/ui/*.rs");
+}

--- a/budget-macros/tests/ui/invalid_arg.rs
+++ b/budget-macros/tests/ui/invalid_arg.rs
@@ -1,0 +1,10 @@
+use budget_macros::budget_cpu_lt;
+
+// The BudgetLimit parser expects either an integer literal or `env`/`config`
+// identifiers. Passing `wrong` should produce a clear error message.
+#[budget_cpu_lt(wrong = "500")]
+fn test_invalid_arg() {
+    let env = ();
+}
+
+fn main() {}

--- a/budget-macros/tests/ui/invalid_arg.stderr
+++ b/budget-macros/tests/ui/invalid_arg.stderr
@@ -1,0 +1,5 @@
+error: expected `env` or `config`, got `wrong`
+ --> tests/ui/invalid_arg.rs:5:17
+  |
+5 | #[budget_cpu_lt(wrong = "500")]
+  |                 ^^^^^

--- a/budget-macros/tests/ui/missing_env.rs
+++ b/budget-macros/tests/ui/missing_env.rs
@@ -1,0 +1,10 @@
+use budget_macros::budget_cpu_lt;
+
+// The macro generates code that references `env.cost_estimate().budget()`,
+// but no `env` variable exists here — this should fail to compile.
+#[budget_cpu_lt(1000)]
+fn test_without_env() {
+    // No `env` variable — should fail to compile.
+}
+
+fn main() {}

--- a/budget-macros/tests/ui/missing_env.stderr
+++ b/budget-macros/tests/ui/missing_env.stderr
@@ -1,0 +1,7 @@
+error[E0423]: expected value, found macro `env`
+ --> tests/ui/missing_env.rs:5:1
+  |
+5 | #[budget_cpu_lt(1000)]
+  | ^^^^^^^^^^^^^^^^^^^^^^ not a value
+  |
+  = note: this error originates in the attribute macro `budget_cpu_lt` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/budget-macros/tests/ui/missing_env_mem.rs
+++ b/budget-macros/tests/ui/missing_env_mem.rs
@@ -1,0 +1,10 @@
+use budget_macros::budget_mem_lt;
+
+// Same as missing_env but exercises budget_mem_lt to confirm both macros
+// produce sensible errors when `env` is absent.
+#[budget_mem_lt(500000)]
+fn test_mem_without_env() {
+    // No `env` variable — should fail to compile.
+}
+
+fn main() {}

--- a/budget-macros/tests/ui/missing_env_mem.stderr
+++ b/budget-macros/tests/ui/missing_env_mem.stderr
@@ -1,0 +1,7 @@
+error[E0423]: expected value, found macro `env`
+ --> tests/ui/missing_env_mem.rs:5:1
+  |
+5 | #[budget_mem_lt(500000)]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^ not a value
+  |
+  = note: this error originates in the attribute macro `budget_mem_lt` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/budget-macros/tests/ui/no_arg.rs
+++ b/budget-macros/tests/ui/no_arg.rs
@@ -1,0 +1,9 @@
+use budget_macros::budget_cpu_lt;
+
+// No argument should fail because the BudgetLimit parser expects a value.
+#[budget_cpu_lt]
+fn test_no_arg() {
+    let env = ();
+}
+
+fn main() {}

--- a/budget-macros/tests/ui/no_arg.stderr
+++ b/budget-macros/tests/ui/no_arg.stderr
@@ -1,0 +1,7 @@
+error: unexpected end of input, expected integer literal
+ --> tests/ui/no_arg.rs:4:1
+  |
+4 | #[budget_cpu_lt]
+  | ^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the attribute macro `budget_cpu_lt` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/budget-macros/tests/ui/on_struct.rs
+++ b/budget-macros/tests/ui/on_struct.rs
@@ -1,0 +1,7 @@
+use budget_macros::budget_cpu_lt;
+
+// The macro expects a function item. Applying it to a struct should fail.
+#[budget_cpu_lt(1000)]
+struct NotAFunction;
+
+fn main() {}

--- a/budget-macros/tests/ui/on_struct.stderr
+++ b/budget-macros/tests/ui/on_struct.stderr
@@ -1,0 +1,5 @@
+error: expected `fn`
+ --> tests/ui/on_struct.rs:5:1
+  |
+5 | struct NotAFunction;
+  | ^^^^^^


### PR DESCRIPTION
## Description

This PR introduces [trybuild](https://crates.io/trybuild) compile-fail tests for the `budget_cpu_lt` and `budget_mem_lt` proc macros in the `budget-macros` crate. Previously, only runtime behavior was tested via standard `#[test]` runners. Now we also verify that the macros produce clear, user-friendly compile-time errors when used incorrectly.

### Changes

**1. Proc-macro error handling (`budget-macros/src/lib.rs`)**
- Replaced two `unwrap()` calls in `generate_budget_assert()` with proper `match` + `syn::Error::into_compile_error()` fallbacks. This ensures invalid macro usage produces a proper `error: expected …` rustc diagnostic instead of a panicked `called Result::unwrap() on an Err value`, which is opaque to the end user.

**2. Dev-dependency (`budget-macros/Cargo.toml`)**
- Added `trybuild = "1.0"` to `[dev-dependencies]`.

**3. Trybuild test harness (`budget-macros/tests/ui.rs`)**
- Standard trybuild entry point: `trybuild::TestCases::new().compile_fail("tests/ui/*.rs")`.

**4. Five intentional misuse test cases (`budget-macros/tests/ui/*.rs`)**

| Test file | What it tests | Expected compile error |
|---|---|---|
| `on_struct.rs` | Applying `#[budget_cpu_lt(1000)]` to a `struct` instead of `fn` | `error: expected fn` |
| `no_arg.rs` | Using `#[budget_cpu_lt]` with no argument | `error: unexpected end of input, expected integer literal` |
| `invalid_arg.rs` | Passing a non-existent identifier `wrong = "500"` | `error: expected env or config, got wrong` |
| `missing_env.rs` | Using `#[budget_cpu_lt(1000)]` on a function with no `env` variable in scope | `error[E0423]: expected value, found macro env` |
| `missing_env_mem.rs` | Same as `missing_env` but exercising `#[budget_mem_lt(500000)]` | `error[E0423]: expected value, found macro env` |

**5. Approved `.stderr` snapshots (`budget-macros/tests/ui/*.stderr`)**
- One `.stderr` file per test case, containing the expected compiler output. These are the trybuild golden files that CI will compare against on every run.

## Related Issue

Closes #37

## Motivation and Context

The `budget_cpu_lt` and `budget_mem_lt` proc macros are developer-facing attributes. When misused (wrong syntax, applied to non-function items, missing required context), the error messages should be immediate, local to the attribute site, and informative — not a mysterious panic buried in macro expansion. This PR guarantees that with automated regression coverage:

- **Prevents accidental degradation** of error quality during future refactors.
- **Documents supported/unsupported usage** through living, executable test cases.
- **Catches regressions in CI** — any change that alters the compile-error output will fail the trybuild test until the `.stderr` snapshot is reviewed and re-approved.

## How Has This Been Tested?

- [x] Added/Updated tests — 5 new trybuild `.rs` + `.stderr` test pairs
- [x] Passed `cargo test -p budget-macros --test ui` — all 5 trybuild cases pass
- [x] Passed `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings
- [x] Formatted with `cargo fmt --all -- --check` — all clean
- [ ] Reviewed or re-measured budget limits — not applicable (no contract/toolchain changes)

```
test tests/ui/invalid_arg.rs ... ok
test tests/ui/missing_env.rs ... ok
test tests/ui/missing_env_mem.rs ... ok
test tests/ui/no_arg.rs ... ok
test tests/ui/on_struct.rs ... ok
test ui_tests ... ok
```

## Types of changes

- [x] New feature (non-breaking change which adds functionality)