### PR TITLE
test: add isolated mock workspace for cargo-budget-report integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "amm-pool-contract"
 version = "0.1.0"
 dependencies = [
@@ -215,6 +224,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_cmd"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2aa3a22042e45de04255c7bf3626e239f450200fd0493c1e382263544b20aea6"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -272,6 +296,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde_core",
+]
+
+[[package]]
 name = "budget-macros"
 version = "0.1.0"
 dependencies = [
@@ -325,11 +360,13 @@ name = "cargo-budget-report"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "assert_cmd",
  "base64 0.21.7",
  "cargo_metadata",
  "clap",
  "csv",
  "indicatif",
+ "predicates",
  "reqwest",
  "serde",
  "serde_json",
@@ -666,6 +703,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -815,6 +858,15 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "fnv"
@@ -1298,6 +1350,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1482,6 +1540,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "predicates"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1577,6 +1665,35 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
 ]
+
+[[package]]
+name = "regex"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
@@ -2250,6 +2367,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2545,6 +2668,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "want"

--- a/cargo-budget-report/Cargo.toml
+++ b/cargo-budget-report/Cargo.toml
@@ -24,3 +24,5 @@ csv = "1.3"
 
 [dev-dependencies]
 tempfile = "3"
+assert_cmd = "2.0"
+predicates = "3.1"

--- a/cargo-budget-report/tests/fixtures/fake_bin/curl
+++ b/cargo-budget-report/tests/fixtures/fake_bin/curl
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Deterministic stand-in for `curl`. cargo-budget-report shells out to `curl`
+# to POST a `simulateTransaction` JSON-RPC request to a live Stellar RPC
+# endpoint; `tests/integration.rs` prepends this directory to PATH so that
+# call is intercepted here instead of reaching the network.
+set -euo pipefail
+
+# Drain stdin (the JSON-RPC payload piped in via `-d @-`) so the real
+# process's pipe never blocks or breaks.
+cat >/dev/null
+
+# `transactionData` is a base64 SorobanTransactionData XDR blob that decodes
+# to instructions=1000000, read_bytes=2048, write_bytes=4096 — the same
+# fixture value used by cargo-budget-report's own unit tests
+# (see fixtures/simulate_transaction_response_valid.json).
+cat <<'JSON'
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "transactionData": "AAAAAAAAAAAAAAAAAA9CQAAACAAAABAAAAAAAAAAAAA=",
+    "minResourceFee": "1000"
+  }
+}
+JSON

--- a/cargo-budget-report/tests/fixtures/fake_bin/stellar
+++ b/cargo-budget-report/tests/fixtures/fake_bin/stellar
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Deterministic stand-in for the real `stellar` CLI. `tests/integration.rs`
+# prepends this directory to PATH so `cargo-budget-report` resolves `stellar`
+# to this script instead of the real CLI, keeping the integration test free
+# of network calls and a funded/configured Stellar identity.
+set -euo pipefail
+
+case "${1:-}" in
+  --version)
+    echo "stellar-cli 0.0.0-mock"
+    ;;
+  contract)
+    case "${2:-}" in
+      deploy)
+        echo "CAMOCKCONTRACTIDAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        ;;
+      invoke)
+        # Real output is a base64 XDR transaction envelope. Its content is
+        # opaque to cargo-budget-report (it's forwarded verbatim to the RPC
+        # `simulateTransaction` call), so any placeholder string is fine here
+        # since `curl` is also mocked below.
+        echo "AAAAAgAAAAA="
+        ;;
+      *)
+        echo "mock stellar: unsupported 'contract' subcommand: ${2:-}" >&2
+        exit 1
+        ;;
+    esac
+    ;;
+  *)
+    echo "mock stellar: unsupported command: ${1:-}" >&2
+    exit 1
+    ;;
+esac

--- a/cargo-budget-report/tests/fixtures/mock_workspace/.gitignore
+++ b/cargo-budget-report/tests/fixtures/mock_workspace/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/cargo-budget-report/tests/fixtures/mock_workspace/Cargo.toml
+++ b/cargo-budget-report/tests/fixtures/mock_workspace/Cargo.toml
@@ -1,0 +1,6 @@
+[workspace]
+resolver = "2"
+members = [
+    "mock_contract_a",
+    "mock_contract_b",
+]

--- a/cargo-budget-report/tests/fixtures/mock_workspace/mock_contract_a/Cargo.toml
+++ b/cargo-budget-report/tests/fixtures/mock_workspace/mock_contract_a/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "mock-contract-a"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]

--- a/cargo-budget-report/tests/fixtures/mock_workspace/mock_contract_a/src/lib.rs
+++ b/cargo-budget-report/tests/fixtures/mock_workspace/mock_contract_a/src/lib.rs
@@ -1,0 +1,16 @@
+//! Minimal `no_std` WASM export used by `cargo-budget-report`'s integration
+//! tests. It carries no Soroban SDK or other dependency so that the mock
+//! workspace builds near-instantly; `cargo-budget-report` only needs a valid
+//! `cdylib` WASM binary with a named export, it does not require the export
+//! to be a real Soroban contract function.
+#![no_std]
+
+#[no_mangle]
+pub extern "C" fn ping() -> i64 {
+    1
+}
+
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    loop {}
+}

--- a/cargo-budget-report/tests/fixtures/mock_workspace/mock_contract_b/Cargo.toml
+++ b/cargo-budget-report/tests/fixtures/mock_workspace/mock_contract_b/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "mock-contract-b"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]

--- a/cargo-budget-report/tests/fixtures/mock_workspace/mock_contract_b/src/lib.rs
+++ b/cargo-budget-report/tests/fixtures/mock_workspace/mock_contract_b/src/lib.rs
@@ -1,0 +1,13 @@
+//! See `mock_contract_a/src/lib.rs` for why this crate is a bare `no_std`
+//! export rather than a real Soroban contract.
+#![no_std]
+
+#[no_mangle]
+pub extern "C" fn pong() -> i64 {
+    2
+}
+
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    loop {}
+}

--- a/cargo-budget-report/tests/fixtures/mock_workspace/rust-toolchain.toml
+++ b/cargo-budget-report/tests/fixtures/mock_workspace/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.85.0"
+targets = ["wasm32-unknown-unknown"]

--- a/cargo-budget-report/tests/integration.rs
+++ b/cargo-budget-report/tests/integration.rs
@@ -1,0 +1,207 @@
+//! End-to-end integration tests for `cargo budget-report`.
+//!
+//! These run the real compiled binary (via `assert_cmd`) against the
+//! isolated, deterministic mock workspace in `tests/fixtures/mock_workspace`
+//! rather than against Tollcraft's own contracts, which made prior ad-hoc
+//! testing brittle and circular.
+//!
+//! The mock workspace's two contracts are bare `no_std` WASM exports with no
+//! dependencies (not real Soroban contracts), so `cargo build` for them is
+//! near-instant. `cargo-budget-report` still shells out to the real
+//! `stellar` CLI and `curl` to deploy/simulate, so both are replaced with
+//! deterministic scripts in `tests/fixtures/fake_bin` (prepended to `PATH`
+//! for the child process). This keeps the suite offline and reproducible:
+//! no live network call, no funded/configured Stellar identity required.
+
+use assert_cmd::Command;
+use predicates::str::contains;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn manifest_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn mock_workspace_fixture() -> PathBuf {
+    manifest_dir().join("tests/fixtures/mock_workspace")
+}
+
+fn fake_bin_dir() -> PathBuf {
+    manifest_dir().join("tests/fixtures/fake_bin")
+}
+
+/// Recursively copies `src` into `dst`, creating `dst` if needed.
+///
+/// The mock workspace is copied into a fresh tempdir per test because
+/// `cargo build` writes `Cargo.lock` and `target/` into its working
+/// directory; running in place would leave build artifacts next to the
+/// checked-in fixture.
+fn copy_dir_all(src: &Path, dst: &Path) {
+    fs::create_dir_all(dst).expect("failed to create destination directory");
+    for entry in fs::read_dir(src).expect("failed to read source directory") {
+        let entry = entry.expect("failed to read directory entry");
+        let file_type = entry.file_type().expect("failed to read file type");
+        let dst_path = dst.join(entry.file_name());
+        if file_type.is_dir() {
+            copy_dir_all(&entry.path(), &dst_path);
+        } else {
+            fs::copy(entry.path(), &dst_path).expect("failed to copy fixture file");
+        }
+    }
+}
+
+/// Copies the mock workspace fixture into a fresh tempdir and returns it.
+fn setup_mock_workspace() -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().expect("failed to create tempdir");
+    copy_dir_all(&mock_workspace_fixture(), tmp.path());
+    tmp
+}
+
+/// `PATH` with the fake `stellar`/`curl` scripts prepended so the CLI under
+/// test resolves them ahead of (or instead of) any real installation, while
+/// still finding the real `cargo`/`rustc` used to build the mock contracts.
+fn mocked_path() -> String {
+    let real_path = std::env::var("PATH").unwrap_or_default();
+    format!("{}:{}", fake_bin_dir().display(), real_path)
+}
+
+/// Builds a ready-to-run `Command` for the compiled `cargo-budget-report`
+/// binary, with its cwd set to `dir` and `PATH` mocked as above.
+fn budget_report_cmd(dir: &Path) -> Command {
+    let mut cmd = Command::cargo_bin("cargo-budget-report").expect("binary should be built");
+    cmd.current_dir(dir).env("PATH", mocked_path());
+    cmd
+}
+
+#[test]
+fn discovers_mock_workspace_and_reports_cleanly() {
+    let workspace = setup_mock_workspace();
+
+    let assert = budget_report_cmd(workspace.path())
+        .args(["budget-report", "--network", "local", "--source", "alice"])
+        .assert();
+
+    let output = assert.success().get_output().clone();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        stdout.contains("WORKSPACE BUDGET REPORT"),
+        "expected report header, got: {stdout}"
+    );
+    assert!(stdout.contains("mock-contract-a"), "got: {stdout}");
+    assert!(stdout.contains("mock-contract-b"), "got: {stdout}");
+    assert!(stdout.contains("CPU Instructions"), "got: {stdout}");
+    assert!(stdout.contains("1,000,000 inst."), "got: {stdout}");
+    assert!(stdout.contains("2,048 B"), "got: {stdout}");
+    assert!(stdout.contains("4,096 B"), "got: {stdout}");
+}
+
+#[test]
+fn json_output_reports_both_mock_contracts() {
+    let workspace = setup_mock_workspace();
+
+    let assert = budget_report_cmd(workspace.path())
+        .args([
+            "budget-report",
+            "--network",
+            "local",
+            "--source",
+            "alice",
+            "--json",
+        ])
+        .assert();
+
+    let output = assert.success().get_output().clone();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let reports: serde_json::Value =
+        serde_json::from_str(&stdout).expect("stdout should be valid JSON");
+    let reports = reports.as_array().expect("report should be a JSON array");
+
+    let packages: std::collections::HashSet<&str> = reports
+        .iter()
+        .map(|r| r["package"].as_str().expect("package should be a string"))
+        .collect();
+    assert!(packages.contains("mock-contract-a"), "got: {reports:?}");
+    assert!(packages.contains("mock-contract-b"), "got: {reports:?}");
+
+    let cpu_entry = reports
+        .iter()
+        .find(|r| r["package"] == "mock-contract-a" && r["metric"] == "CPU Instructions")
+        .expect("CPU Instructions entry for mock-contract-a should be present");
+    assert_eq!(cpu_entry["value"], 1_000_000);
+
+    let wasm_bytes_entry = reports
+        .iter()
+        .find(|r| r["package"] == "mock-contract-b" && r["metric"] == "WASM Bytes")
+        .expect("WASM Bytes entry for mock-contract-b should be present");
+    assert!(
+        wasm_bytes_entry["value"].as_u64().unwrap_or(0) > 0,
+        "got: {wasm_bytes_entry:?}"
+    );
+}
+
+#[test]
+fn check_flag_passes_when_limits_are_generous() {
+    let workspace = setup_mock_workspace();
+    fs::write(
+        workspace.path().join("budget.toml"),
+        "[functions.ping]\n\
+         cpu_limit = 5000000\n\
+         read_limit = 5000\n\
+         write_limit = 5000\n\
+         \n\
+         [functions.pong]\n\
+         cpu_limit = 5000000\n\
+         read_limit = 5000\n\
+         write_limit = 5000\n",
+    )
+    .expect("failed to write budget.toml");
+
+    let assert = budget_report_cmd(workspace.path())
+        .args([
+            "budget-report",
+            "--network",
+            "local",
+            "--source",
+            "alice",
+            "--check",
+        ])
+        .assert();
+
+    let output = assert.success().get_output().clone();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("=== BUDGET CHECKS ==="), "got: {stdout}");
+    assert!(
+        stdout.contains("Summary: 6 check(s) passed, 0 failed"),
+        "got: {stdout}"
+    );
+}
+
+#[test]
+fn check_flag_fails_when_a_limit_is_exceeded() {
+    let workspace = setup_mock_workspace();
+    fs::write(
+        workspace.path().join("budget.toml"),
+        "[functions.ping]\n\
+         cpu_limit = 10\n\
+         \n\
+         [functions.pong]\n\
+         cpu_limit = 5000000\n",
+    )
+    .expect("failed to write budget.toml");
+
+    let mut cmd = budget_report_cmd(workspace.path());
+    cmd.args([
+        "budget-report",
+        "--network",
+        "local",
+        "--source",
+        "alice",
+        "--check",
+    ]);
+
+    cmd.assert()
+        .failure()
+        .stdout(contains("mock-contract-a::ping [CPU Instructions]"))
+        .stdout(contains("FAIL"));
+}


### PR DESCRIPTION
Closes #51

## Summary

`cargo-budget-report` had no integration test suite — the only way to exercise it end-to-end was against Tollcraft's own contracts, which is brittle (real network dependency, real deploy costs) and circular (tests would depend on the very contracts the tool is meant to measure). This PR adds an isolated, deterministic mock workspace fixture plus a `tests/integration.rs` that drives the compiled binary against it with `assert_cmd`, without touching a live network or requiring a funded/configured Stellar identity.

## New files

- `cargo-budget-report/tests/fixtures/mock_workspace/` — a minimal, self-contained two-crate Cargo workspace (`mock_contract_a` / `mock_contract_b`), each a bare `#![no_std]` `cdylib` with a single `#[no_mangle] extern "C"` export and a manual `#[panic_handler]`. No external dependencies (not even `soroban-sdk`), so `cargo build --target wasm32-unknown-unknown --release` for each finishes in a couple of seconds. `cargo-budget-report` only needs a valid `cdylib` WASM binary with a named export in its export section — it doesn't require the export to be a real Soroban contract function — so this keeps compilation overhead in `cargo test` to a minimum, per the issue's implementation guideline.
  - `Cargo.toml` — workspace root (`members = ["mock_contract_a", "mock_contract_b"]`); isolated from the repo's real workspace since it isn't listed in the root `Cargo.toml`'s explicit `members`, and it declares its own `[workspace]` table so cargo doesn't walk up into the parent workspace.
  - `rust-toolchain.toml` — mirrors the repo root's pinned toolchain/target so the fixture builds with the same toolchain already required project-wide.
  - `.gitignore` — ignores the fixture's own `/target` and `Cargo.lock` (each test run gets a fresh copy anyway, see below).
  - `mock_contract_a/`, `mock_contract_b/` — `Cargo.toml` + `src/lib.rs` each.
- `cargo-budget-report/tests/fixtures/fake_bin/stellar` and `.../curl` — small, deterministic shell scripts standing in for the real `stellar` CLI and `curl`. `cargo-budget-report` shells out to both (`stellar --version` for the preflight check, `stellar contract deploy` / `stellar contract invoke --build-only`, then `curl` to POST `simulateTransaction` to the RPC endpoint). The test prepends this directory to `PATH` before invoking the binary, so every one of those calls is intercepted and answered with canned, deterministic output instead of reaching a real network or CLI — this is the "mock or bypass the RPC check" the issue asks for. The canned `transactionData` XDR blob is the same one already used by `cargo-budget-report`'s own unit tests (`fixtures/simulate_transaction_response_valid.json`), decoding to instructions=1,000,000 / read_bytes=2,048 / write_bytes=4,096.
- `cargo-budget-report/tests/integration.rs` — the integration suite (see Tests below).

## Modified files

- `cargo-budget-report/Cargo.toml` — added `assert_cmd` and `predicates` to `[dev-dependencies]`.
- `Cargo.lock` — updated for the above.

## Implementation details

- Each test copies the mock workspace fixture into a fresh `tempfile::tempdir()` before invoking the CLI (`cargo build` writes `Cargo.lock`/`target/` into its cwd, so building in place would leave artifacts next to the checked-in fixture and let tests interfere with each other).
- `budget_report_cmd()` builds an `assert_cmd::Command` for the compiled `cargo-budget-report` binary with `current_dir` set to the scratch copy and `PATH` set to `fake_bin` + the real `PATH`, so the fake `stellar`/`curl` resolve first while the real `cargo`/`rustc` (needed to actually build the mock contracts to WASM) still resolve normally.
- The CLI is invoked the same way `cargo` invokes any `cargo-*` subcommand plugin: first arg `budget-report`, matching the `CargoCli::BudgetReport` clap variant.

## Tests added (`cargo-budget-report/tests/integration.rs`)

- `discovers_mock_workspace_and_reports_cleanly` — runs `cargo budget-report --network local --source alice` against the mock workspace, asserts a clean exit and that the plain-text report contains both mock package names, the `CPU Instructions` metric, and correctly formatted values (`1,000,000 inst.`, `2,048 B`, `4,096 B`).
- `json_output_reports_both_mock_contracts` — same, with `--json`; parses stdout as JSON and asserts both packages are present, the CPU Instructions value for `mock-contract-a` is `1000000`, and a `WASM Bytes` entry with a positive value exists for `mock-contract-b`.
- `check_flag_passes_when_limits_are_generous` — writes a `budget.toml` with generous `cpu_limit`/`read_limit`/`write_limit` for both mock functions, runs with `--check`, asserts a clean exit and `Summary: 6 check(s) passed, 0 failed`.
- `check_flag_fails_when_a_limit_is_exceeded` — writes a `budget.toml` with an unreasonably low `cpu_limit` for one function, runs with `--check`, asserts a non-zero exit and a `FAIL` line for that function/metric.

Together these cover both "done" criteria from the issue: successful discovery + clean exit, and the CLI's `--check` "expected formatting" failure path — all without any live network call.

## How to test

```
cargo test --test integration -p cargo-budget-report
```

Output:

```
running 4 tests
test check_flag_fails_when_a_limit_is_exceeded ... ok
test check_flag_passes_when_limits_are_generous ... ok
test discovers_mock_workspace_and_reports_cleanly ... ok
test json_output_reports_both_mock_contracts ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.26s
```

Also ran, per `CONTRIBUTING.md`:

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test -p cargo-budget-report -p budget-macros` — all 32 unit tests, 4 new integration tests, and the 2 existing pre-commit-hook tests pass

Note: `cargo test --workspace` currently fails in `amm-pool-contract`'s `budget_test.rs` (`HostError: WasmVm, MissingValue... trying to invoke non-existent contract function "initialize"`) on this branch. This is pre-existing on `main` as well (verified by stashing this PR's changes and re-running against unmodified `main`) and unrelated to this change — this PR doesn't touch `amm-pool-contract` or its test snapshots.
