### PR TITLE
feat: add budget assertion for extend_ttl operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive unit tests for the cost-value formatter covering zero, single digits, thousands/millions boundaries, and `u32::MAX` across both unit suffixes.
 - Contributors should add a short changelog entry with their pull request when the change is user-visible.
 - Budget assertion tests for `require_auth` host calls: isolated `require_auth_only` contract function with CPU/memory budget assertions, plus per-operation deposit/swap/withdraw granular budget checks.
+- Budget assertion tests for `extend_ttl` operations: isolated `extend_instance_ttl` contract function with CPU/memory budget assertions and deliberate-regression fixtures, demonstrating how to budget-test ledger-rent operations.
 
 ### Fixed
 

--- a/amm-pool-contract/src/lib.rs
+++ b/amm-pool-contract/src/lib.rs
@@ -148,6 +148,16 @@ impl ConstantProductPool {
         addr.require_auth();
     }
 
+    /// Extends the TTL of this contract's instance storage (and its Wasm
+    /// code) so neither is evicted from the ledger before `extend_to`
+    /// ledgers from now, provided the current TTL is below `threshold`
+    /// ledgers. Touches no pool state; isolated purely so its cost can be
+    /// measured/asserted on its own, the same way `require_auth_only`
+    /// isolates `require_auth`.
+    pub fn extend_instance_ttl(env: Env, threshold: u32, extend_to: u32) {
+        env.storage().instance().extend_ttl(threshold, extend_to);
+    }
+
     pub fn do_expensive_work(env: Env, n: u32) -> u32 {
         let mut result: u32 = 0;
 

--- a/amm-pool-contract/tests/budget_test.rs
+++ b/amm-pool-contract/tests/budget_test.rs
@@ -158,6 +158,48 @@ fn test_budget_require_auth_deliberate_regression_mem() {
 }
 
 #[test]
+#[budget_cpu_lt(50000000)]
+fn test_budget_extend_ttl_isolated() {
+    let env = Env::default();
+    let (client, _user) = setup_wasm(&env);
+
+    client.extend_instance_ttl(&100, &10_000);
+}
+
+#[test]
+#[budget_mem_lt(2000000)]
+fn test_budget_extend_ttl_isolated_mem() {
+    let env = Env::default();
+    let (client, _user) = setup_wasm(&env);
+
+    client.extend_instance_ttl(&100, &10_000);
+}
+
+#[test]
+#[should_panic(
+    expected = "local estimate, real network cost may differ significantly in either direction"
+)]
+#[budget_cpu_lt(1000)] // Deliberate regression: extend_ttl costs well above 1K CPU
+fn test_budget_extend_ttl_deliberate_regression_cpu() {
+    let env = Env::default();
+    let (client, _user) = setup_wasm(&env);
+
+    client.extend_instance_ttl(&100, &10_000);
+}
+
+#[test]
+#[should_panic(
+    expected = "local estimate, real network cost may differ significantly in either direction"
+)]
+#[budget_mem_lt(1)] // Deliberate regression: any real memory cost exceeds an impossible 1-byte limit
+fn test_budget_extend_ttl_deliberate_regression_mem() {
+    let env = Env::default();
+    let (client, _user) = setup_wasm(&env);
+
+    client.extend_instance_ttl(&100, &10_000);
+}
+
+#[test]
 #[budget_cpu_lt(2500000)]
 fn test_budget_macro_gated() {
     let env = Env::default();


### PR DESCRIPTION
Closes #56

## Summary

`amm-pool-contract`'s budget test suite covers pool operations (`deposit`/`swap`/`withdraw`) and `require_auth` in isolation, but had no coverage for `extend_ttl` — the ledger-rent operation every long-lived Soroban contract needs to call periodically to avoid storage eviction. This PR adds an isolated contract function that performs an `extend_ttl` call and budget-asserts its CPU/memory cost, following the exact pattern already established for `require_auth_only`.

## Modified files

- `amm-pool-contract/src/lib.rs` — new `extend_instance_ttl` contract function.
- `amm-pool-contract/tests/budget_test.rs` — four new budget assertion tests.
- `CHANGELOG.md` — `Unreleased` entry.

No new files; no files deleted.

## Implementation details

- `ConstantProductPool::extend_instance_ttl(env: Env, threshold: u32, extend_to: u32)` (`amm-pool-contract/src/lib.rs`) calls `env.storage().instance().extend_ttl(threshold, extend_to)` — the `Instance` storage API's TTL-extension call (extends both the contract instance and its Wasm code's TTL). It's a standalone function that touches no pool state (reserves/shares/balances), mirroring how `require_auth_only` isolates `require_auth` from the rest of the contract's logic so its cost can be measured on its own rather than folded into a `deposit`/`swap`/`withdraw` measurement.
- `threshold`/`extend_to` are taken as function arguments (not hardcoded) so callers/tests can exercise different TTL windows; the tests below use `threshold = 100, extend_to = 10_000` as representative values.

## Tests added (`amm-pool-contract/tests/budget_test.rs`)

Four tests, directly mirroring the existing `test_budget_require_auth_isolated*` / `test_budget_require_auth_deliberate_regression_*` group:

- `test_budget_extend_ttl_isolated` — `#[budget_cpu_lt(50000000)]`, calls `client.extend_instance_ttl(&100, &10_000)` and asserts the measured CPU instruction cost stays under the same generous bound used by the other isolated-operation tests in this file.
- `test_budget_extend_ttl_isolated_mem` — `#[budget_mem_lt(2000000)]`, same call, asserting memory-bytes cost.
- `test_budget_extend_ttl_deliberate_regression_cpu` — `#[should_panic(expected = "local estimate, real network cost may differ significantly in either direction")]` with `#[budget_cpu_lt(1000)]`, an impossibly tight limit that documents what a CPU budget breach looks like for this operation (matches the existing deliberate-regression fixture pattern used for `require_auth` and the macro/read-bytes groups).
- `test_budget_extend_ttl_deliberate_regression_mem` — same idea with `#[budget_mem_lt(1)]`.

All four use the existing `setup_wasm()` fixture (registers the real compiled WASM, not the in-memory Rust type, since WASM-level execution is required for accurate budget measurements per the existing comment in that helper).

## How to test

```
cargo build -p amm-pool-contract --release --target wasm32-unknown-unknown
cargo test -p amm-pool-contract --test budget_test
```

Output:

```
running 26 tests
test test_budget_extend_ttl_deliberate_regression_mem - should panic ... ok
test test_budget_extend_ttl_deliberate_regression_cpu - should panic ... ok
test test_budget_extend_ttl_isolated ... ok
test test_budget_extend_ttl_isolated_mem ... ok
... (22 pre-existing tests, unchanged) ...
test result: ok. 26 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 13.11s
```

Also ran, per `CONTRIBUTING.md`:

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — clean, no regressions (32 `cargo-budget-report` unit tests, 2 pre-commit-hook tests, 26 `amm-pool-contract` budget tests, `budget-macros` trybuild tests)
