### PR TITLE
fix: CI records genuine cargo-budget-report data instead of mocked JSON (#91)

### DIFF
--- a/.github/workflows/budget.yml
+++ b/.github/workflows/budget.yml
@@ -22,7 +22,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.93.0
-          target: wasm32v1-none
+          targets: wasm32v1-none wasm32-unknown-unknown
 
       - name: Install System Dependencies
         run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config libudev-dev
@@ -32,6 +32,11 @@ jobs:
           curl -sL https://github.com/stellar/stellar-cli/releases/download/v21.5.3/stellar-cli-21.5.3-x86_64-unknown-linux-gnu.tar.gz | tar -xz
           mv stellar ~/.cargo/bin/
 
+      - name: Configure Stellar Identity
+        run: stellar keys add alice --secret-key "${{ secrets.ALICE_SECRET_KEY }}"
+        env:
+          STELLAR_ACCOUNT: alice
+
       - name: Build Contracts
         run: cargo build -p amm-pool-contract --release --target wasm32v1-none
 
@@ -40,13 +45,20 @@ jobs:
 
       - name: Run Budget Report (Tier B)
         run: |
-          # Optionally, this uses budget.toml to populate fields instead of args
-          # Ensure your repository has budget.toml configured for this to work
-          # and ALICE_SECRET_KEY is in your Github Secrets for deploying to testnet
-          # cargo run --bin cargo-budget-report -- budget-report --json > current_report.json
-
-          # Mocking the JSON output for the demo so CI passes without testnet secrets:
-          echo '[{"package":"amm-pool-contract","function":"do_expensive_work","metric":"CPU Instructions","value":1000000},{"package":"amm-pool-contract","function":"do_expensive_work","metric":"Read Bytes","value":4096}]' > current_report.json
+          set -e
+          attempt=0
+          max_attempts=4
+          delay=5
+          until cargo run --bin cargo-budget-report -- budget-report --json > current_report.json; do
+            attempt=$((attempt + 1))
+            if [ "$attempt" -ge "$max_attempts" ]; then
+              echo "cargo-budget-report failed after $max_attempts attempts. Aborting."
+              exit 1
+            fi
+            echo "Attempt $attempt/$max_attempts failed. Retrying in ${delay}s..."
+            sleep "$delay"
+            delay=$((delay * 2))
+          done
 
       - name: Upload Budget Report
         uses: actions/upload-artifact@v4.2.0


### PR DESCRIPTION
# Closes #91

## Summary

Replaces the hardcoded mock JSON in the **Run Budget Report (Tier B)** step with a real `cargo-budget-report` invocation that contacts testnet.

## Changes

1. **Real invocation** — `cargo run --bin cargo-budget-report -- budget-report --json > current_report.json` now runs instead of `echo '[mock]'`.
2. **Stellar identity** — new **Configure Stellar Identity** step runs `stellar keys add alice` using `${{ secrets.ALICE_SECRET_KEY }}` so testnet simulation can succeed.
3. **wasm32 target** — adds `wasm32-unknown-unknown` to the toolchain targets (needed by cargo-budget-report's internal build).
4. **Retry wrapper** — up to 4 attempts with exponential backoff; exits non-zero on final failure. No fallback to fabricated data.
5. **Mock removed** — commented-out code and static JSON are gone. `current_report.json` is always the genuine output.

## Verification

A real (non-mocked) CI run should be shown producing a genuine `current_report.json` in the PR checks before merging.
