### PR TITLE
feat: implement and validate the shared budget.toml schema across both Tollcraft tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,30 @@ To overwrite an existing file, add `--force`:
 cargo budget-report --init --force
 ```
 
+The `budget.toml` file is shared between both Tollcraft tools —
+`cargo-budget-report` and `soroban-cost-linter` — so a single file at the
+workspace root serves both tools. Each tool silently ignores sections it
+does not own. Unknown keys inside `[functions.*]` blocks produce an error
+pointing to the offending key.
+
+Full shared schema:
+
+```toml
+# -- cargo-budget-report configuration ----------------------------------------
+network = "testnet"           # Target network: "testnet", "futurenet", "local"
+source = "alice"              # Stellar source account keypair name
+
+[functions.do_expensive_work]
+args = ["--n", "10000"]       # CLI arguments forwarded to the function
+cpu_limit = 5000000           # Optional CPU instruction limit (--check)
+read_limit = 5000             # Optional read-bytes limit (--check)
+write_limit = 1000            # Optional write-bytes limit (--check)
+
+# -- soroban-cost-linter configuration ----------------------------------------
+[lints]                       # Consumed by soroban-cost-linter; silently
+complexity = "warn"           # accepted by cargo-budget-report.
+```
+
 ### 3. Usage
 
 **Generate a Workspace Report:**

--- a/cargo-budget-report/fixtures/shared_budget.toml
+++ b/cargo-budget-report/fixtures/shared_budget.toml
@@ -1,0 +1,24 @@
+# -- Shared budget.toml -------------------------------------------------------
+# This file exercises the full shared schema consumed by both Tollcraft tools:
+#
+#   cargo-budget-report  -- network, source, [functions.*]
+#   soroban-cost-linter  -- [lints] (and any other foreign top-level sections)
+#
+# Foreign sections are silently accepted so that a single file can serve both
+# tools without parse errors.
+
+network = "testnet"
+source = "alice"
+
+[functions.do_expensive_work]
+args = ["--n", "10000"]
+cpu_limit = 5000000
+read_limit = 5000
+write_limit = 1000
+
+[functions.require_auth_only]
+args = ["--addr", "alice"]
+
+# -- Linter configuration (consumed by soroban-cost-linter) -------------------
+[lints]
+complexity = "warn"

--- a/cargo-budget-report/src/main.rs
+++ b/cargo-budget-report/src/main.rs
@@ -1257,10 +1257,9 @@ mod tests {
 
     #[test]
     fn unknown_function_keys_produce_error() {
-        let err = toml::from_str::<BudgetToml>(
-            "[functions.do_expensive_work]\ncpu_lmit = 5000000\n",
-        )
-        .unwrap_err();
+        let err =
+            toml::from_str::<BudgetToml>("[functions.do_expensive_work]\ncpu_lmit = 5000000\n")
+                .unwrap_err();
         let err_text = err.to_string();
         assert!(
             err_text.contains("unknown field") || err_text.contains("cpu_lmit"),

--- a/cargo-budget-report/src/main.rs
+++ b/cargo-budget-report/src/main.rs
@@ -48,6 +48,10 @@ source = "alice"
 #
 # A missing `*_limit` field means that metric is reported but not enforced.
 # See `cargo budget-report --check` for limit enforcement.
+# Unknown keys inside a [functions.*] block produce an error.
+#
+# Foreign top-level sections (e.g. [lints] for soroban-cost-linter) are
+# silently accepted so that both tools can share a single budget.toml.
 
 [functions.do_expensive_work]
 args = ["--n", "10000"]
@@ -156,6 +160,7 @@ impl TransactionData {
 /// Controls which CLI arguments are forwarded to the contract invocation
 /// and which resource limits are enforced in `--check` mode.
 #[derive(serde::Deserialize, Default, Debug)]
+#[serde(deny_unknown_fields)]
 struct FunctionConfig {
     #[serde(default)]
     args: Vec<String>,
@@ -972,6 +977,8 @@ mod tests {
     use std::time::{SystemTime, UNIX_EPOCH};
     use stellar_xdr::curr::WriteXdr;
 
+    const SHARED_BUDGET_TOML: &str = include_str!("../fixtures/shared_budget.toml");
+
     fn unique_test_path() -> PathBuf {
         let mut path = std::env::temp_dir();
         let nanos = SystemTime::now()
@@ -1236,6 +1243,46 @@ mod tests {
         assert!(err_text.contains("failed to parse"));
         assert!(err_text.contains("line") || err_text.contains("Line"));
         assert!(err_text.contains("column") || err_text.contains("Column"));
+    }
+
+    #[test]
+    fn shared_budget_toml_parses_with_foreign_sections() {
+        let config: BudgetToml = toml::from_str(SHARED_BUDGET_TOML)
+            .expect("shared budget.toml with foreign [lints] section should parse");
+        assert_eq!(config.network.as_deref(), Some("testnet"));
+        assert_eq!(config.source.as_deref(), Some("alice"));
+        assert!(config.functions.contains_key("do_expensive_work"));
+        assert!(config.functions.contains_key("require_auth_only"));
+    }
+
+    #[test]
+    fn unknown_function_keys_produce_error() {
+        let err = toml::from_str::<BudgetToml>(
+            "[functions.do_expensive_work]\ncpu_lmit = 5000000\n",
+        )
+        .unwrap_err();
+        let err_text = err.to_string();
+        assert!(
+            err_text.contains("unknown field") || err_text.contains("cpu_lmit"),
+            "expected error mentioning unknown field or the offending key, got: {err_text}"
+        );
+    }
+
+    #[test]
+    fn known_function_key_spelling_produces_correct_deserialization() {
+        let config: BudgetToml = toml::from_str(
+            r#"
+[functions.do_expensive_work]
+cpu_limit = 5000000
+read_limit = 5000
+write_limit = 1000
+"#,
+        )
+        .expect("valid function config should parse");
+        let func = &config.functions["do_expensive_work"];
+        assert_eq!(func.cpu_limit, Some(5000000));
+        assert_eq!(func.read_limit, Some(5000));
+        assert_eq!(func.write_limit, Some(1000));
     }
 
     // --- TransactionData deserialization tests ---


### PR DESCRIPTION
# Closes #119

## Summary

soroban-cost-linter's README states that both Tollcraft tools "share configuration via a unified budget.toml file". This side of that claim was unenforced: `BudgetToml` in `cargo-budget-report` silently ignored everything but `network`, `source`, and `[functions.*]` — including a `[lints]` table meant for the linter, and including any key the user misspells. The two tools coexisted only because serde ignores unknown fields by default — an accident, not a contract.

## Changes

### Enforced schema (`cargo-budget-report/src/main.rs`)
- Added **`#[serde(deny_unknown_fields)]`** to `FunctionConfig` — unknown keys inside `[functions.*]` blocks (e.g. `cpu_lmit`) now produce a parse error naming the offending key
- The root `BudgetToml` struct intentionally omits `deny_unknown_fields` — foreign top-level sections like `[lints]` (consumed by `soroban-cost-linter`) parse silently without warning or error
- Updated the **`--init` template** (`BUDGET_TOML_TEMPLATE`) to document the shared-schema contract

### Fixture
- **`cargo-budget-report/fixtures/shared_budget.toml`** — a checked-in fixture carrying both tools' sections (`network`, `source`, `[functions.*]`, and `[lints]`)

### Tests
- `shared_budget_toml_parses_with_foreign_sections` — verifies the fixture loads correctly
- `unknown_function_keys_produce_error` — verifies `cpu_lmit` (typo) produces a deserialization error
- `known_function_key_spelling_produces_correct_deserialization` — verifies the correct field names work

### Documentation (`README.md`)
- Expanded the **Configuration** section to show the full shared schema, documenting which sections belong to which tool and explicitly noting that foreign sections are silently accepted

## Design decisions

- `deny_unknown_fields` is applied per-struct (on `FunctionConfig`) but explicitly not on the root `BudgetToml`, matching the requirement that foreign top-level sections parse without error
- The fixture simulates the real-world shared config that users will author — both tools' sections in one file
