### PR TITLE
chore: replace .unwrap() in budget-macros codegen with proper compile error

### DIFF
--- a/budget-macros/src/lib.rs
+++ b/budget-macros/src/lib.rs
@@ -153,7 +153,10 @@ fn generate_budget_assert(
         }
     };
 
-    *input_fn.block = syn::parse2(new_block).unwrap();
+    *input_fn.block = match syn::parse2(new_block) {
+        Ok(block) => block,
+        Err(e) => return TokenStream::from(e.into_compile_error()),
+    };
 
     TokenStream::from(quote! {
         #input_fn


### PR DESCRIPTION
# Closes #95

## Problem

Both `budget_cpu_lt` and `budget_mem_lt` re-parsed their own generated token stream via `syn::parse2` and called `.unwrap()` on the result (`budget-macros/src/lib.rs:156`). Since the token stream is produced by a `quote!` template, any future edit that generates subtly invalid tokens would surface as an opaque proc-macro panic (an "internal compiler error"-style message) rather than a normal Rust compile error pointing at the problem.

## Solution

Replaced the `.unwrap()` with a `match` that returns the parsed block on success or converts the `syn::Error` to a `TokenStream` via `into_compile_error()` on failure. This matches the existing error-handling pattern used for the `BudgetLimit` and `ItemFn` parses earlier in the same function.

## Testing

- All existing tests pass (`cargo test -p budget-macros`)
- Existing UI tests (`invalid_arg`, `missing_env`, `missing_env_mem`, `no_arg`, `on_struct`) continue to pass
- Macro behavior for valid inputs is unchanged

## Implementation notes

- Only one call site needed changing since both macros flow through the shared `generate_budget_assert` function
- No behavioral change for valid input — the fix only affects the error-reporting path