### PR TITLE
test: add fixture for contract exceeding CPU budget

### DIFF
--- a/cargo-budget-report/fixtures/simulate_transaction_response_cpu_exceeded.json
+++ b/cargo-budget-report/fixtures/simulate_transaction_response_cpu_exceeded.json
@@ -1,0 +1,13 @@
+{
+  "_metadata": {
+    "network": "testnet",
+    "protocol_version": 21,
+    "generated_by": "soroban-budget-assert test fixture",
+    "description": "simulateTransaction response where contract exceeds CPU budget"
+  },
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "error": "simulation failed: HostError: Error(WasmVm, InvalidAction)\n\nCPU budget exceeded"
+  }
+}

--- a/cargo-budget-report/src/main.rs
+++ b/cargo-budget-report/src/main.rs
@@ -1256,7 +1256,10 @@ mod tests {
             "extraction should fail on malformed response"
         );
         let err = format!("{:#}", result.unwrap_err());
-        assert!(err.contains("No transaction data available"), "Expected specific error message");
+        assert!(
+            err.contains("No transaction data available"),
+            "Expected specific error message"
+        );
     }
 
     #[test]
@@ -1265,7 +1268,8 @@ mod tests {
             .join("fixtures")
             .join("simulate_transaction_response_cpu_exceeded.json");
         let fixture_json: serde_json::Value = serde_json::from_str(
-            &std::fs::read_to_string(&fixture_path).expect("failed to read cpu exceeded fixture file"),
+            &std::fs::read_to_string(&fixture_path)
+                .expect("failed to read cpu exceeded fixture file"),
         )
         .expect("failed to parse cpu exceeded JSON");
 
@@ -1275,7 +1279,11 @@ mod tests {
             "extraction should fail on cpu exceeded response"
         );
         let err = format!("{:#}", result.unwrap_err());
-        assert!(err.contains("CPU budget exceeded"), "Expected error to mention CPU budget exceeded, got: {}", err);
+        assert!(
+            err.contains("CPU budget exceeded"),
+            "Expected error to mention CPU budget exceeded, got: {}",
+            err
+        );
     }
 
     #[test]

--- a/cargo-budget-report/src/main.rs
+++ b/cargo-budget-report/src/main.rs
@@ -325,6 +325,18 @@ fn extract_metrics(rpc_response: &serde_json::Value) -> Result<(u32, u32, u32)> 
         anyhow::bail!("{}", error);
     }
 
+    if let Some(error) = rpc_response.get("result").and_then(|r| r.get("error")) {
+        let err_msg = error.as_str().unwrap_or_else(|| {
+            // Fallback for non-string error (shouldn't happen in valid JSON-RPC, but just in case)
+            ""
+        });
+        if !err_msg.is_empty() {
+            anyhow::bail!("{}", err_msg);
+        } else {
+            anyhow::bail!("{}", error);
+        }
+    }
+
     let tx_data_b64 = rpc_response["result"]["transactionData"]
         .as_str()
         .context("No transactionData found in simulateTransaction response.")?;
@@ -1243,6 +1255,27 @@ mod tests {
             result.is_err(),
             "extraction should fail on malformed response"
         );
+        let err = format!("{:#}", result.unwrap_err());
+        assert!(err.contains("No transaction data available"), "Expected specific error message");
+    }
+
+    #[test]
+    fn extract_metrics_from_cpu_exceeded_fixture_file() {
+        let fixture_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("fixtures")
+            .join("simulate_transaction_response_cpu_exceeded.json");
+        let fixture_json: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(&fixture_path).expect("failed to read cpu exceeded fixture file"),
+        )
+        .expect("failed to parse cpu exceeded JSON");
+
+        let result = extract_metrics(&fixture_json);
+        assert!(
+            result.is_err(),
+            "extraction should fail on cpu exceeded response"
+        );
+        let err = format!("{:#}", result.unwrap_err());
+        assert!(err.contains("CPU budget exceeded"), "Expected error to mention CPU budget exceeded, got: {}", err);
     }
 
     #[test]

--- a/cargo-budget-report/src/main.rs
+++ b/cargo-budget-report/src/main.rs
@@ -326,10 +326,7 @@ fn extract_metrics(rpc_response: &serde_json::Value) -> Result<(u32, u32, u32)> 
     }
 
     if let Some(error) = rpc_response.get("result").and_then(|r| r.get("error")) {
-        let err_msg = error.as_str().unwrap_or_else(|| {
-            // Fallback for non-string error (shouldn't happen in valid JSON-RPC, but just in case)
-            ""
-        });
+        let err_msg = error.as_str().unwrap_or("");
         if !err_msg.is_empty() {
             anyhow::bail!("{}", err_msg);
         } else {


### PR DESCRIPTION
Closes #68

### Summary
Adds a fixture and test handling for when a Soroban contract simulation exceeds the CPU budget.

### What Changed
- Added `simulate_transaction_response_cpu_exceeded.json` fixture.
- Updated `extract_metrics` to recognize and properly bubble up errors stored in `result.error` returned by standard `simulateTransaction` failure payloads.
- Added a new unit test for this parsing logic.

### Checklist
- [x] No regressions in existing code
- [x] Added tests for the new behavior
- [x] Scope confined to acceptance criteria