### PR TITLE
docs: fix dead GitBook link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ fn test_mem_budget() {
 
 ## 📊 Measurements
 
-The [MEASUREMENTS.md](MEASUREMENTS.md) file at the repository root records all empirical cost measurements comparing local Soroban budget estimates against real network costs. The [Protocol Mechanics documentation](https://tollcraft.gitbook.io/docs/budget-assert/protocol-mechanics) cites this file as the source of truth for measured figures.
+The [MEASUREMENTS.md](MEASUREMENTS.md) file at the repository root records all empirical cost measurements comparing local Soroban budget estimates against real network costs. The [Protocol Mechanics documentation](https://tollcraft.gitbook.io/docs/budget-assert/mechanics) cites this file as the source of truth for measured figures.
 
 ## 🤝 Community & Maintainers
 


### PR DESCRIPTION
The "Protocol Mechanics documentation" link pointed to .../budget-assert/protocol-mechanics, which returns a 404. The GitBook space uses the source filename as the page slug (mechanics.md), so the canonical URL is .../budget-assert/mechanics. Verified all other README links resolve to current reference materials.

Closes #234

## Description
<!-- Describe your changes in detail -->

## Related Issue
<!-- If this PR addresses an existing issue, please link it here. -->
Closes #

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
- [ ] Added/Updated tests
- [ ] Passed `cargo test`
- [ ] Passed `cargo clippy`
- [ ] Formatted with `cargo fmt`
- [ ] Reviewed or re-measured budget limits in `amm-pool-contract/tests/budget_test.rs` when contract, build profile, or toolchain changes may affect them

## Types of changes
<!-- What types of changes does your code introduce? -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
