### PR TITLE
feat: allow overriding the cargo build profile

### DIFF
--- a/cargo-budget-report/src/main.rs
+++ b/cargo-budget-report/src/main.rs
@@ -116,6 +116,13 @@ struct BudgetReportArgs {
     /// regardless of this flag.
     #[arg(long, default_value_t = false)]
     quiet: bool,
+
+    /// Cargo build profile to use when compiling the contract WASM.
+    ///
+    /// Defaults to `release` when not provided. Custom profiles (e.g.
+    /// `release-opt`) must be defined in the project's `Cargo.toml`.
+    #[arg(long)]
+    profile: Option<String>,
 }
 
 /// Top-level configuration deserialized from `budget.toml`.
@@ -728,6 +735,8 @@ fn main() -> Result<()> {
     let mut has_errors = false;
     let mut checks_failed = false;
 
+    let build_profile = args.profile.as_deref().unwrap_or("release");
+
     for package in metadata.packages {
         let is_cdylib = package
             .targets
@@ -747,7 +756,8 @@ fn main() -> Result<()> {
                 &package.name,
                 "--target",
                 "wasm32-unknown-unknown",
-                "--release",
+                "--profile",
+                build_profile,
             ])
             .status()
             .context("failed to build package")?;
@@ -761,7 +771,7 @@ fn main() -> Result<()> {
         let wasm_path = metadata
             .target_directory
             .join("wasm32-unknown-unknown")
-            .join("release")
+            .join(build_profile)
             .join(format!("{}.wasm", wasm_name));
 
         if !wasm_path.exists() {

--- a/cargo-budget-report/tests/integration.rs
+++ b/cargo-budget-report/tests/integration.rs
@@ -269,3 +269,59 @@ fn retry_mechanism_fails_after_exhausting_all_attempts() {
         "stderr should mention source account funding, got: {stderr:?}"
     );
 }
+
+// ── Build profile integration tests ────────────────────────────────────
+
+#[test]
+fn profile_flag_explicit_release_produces_same_report() {
+    let workspace = setup_mock_workspace();
+
+    let assert = budget_report_cmd(workspace.path())
+        .args([
+            "budget-report",
+            "--network",
+            "local",
+            "--source",
+            "alice",
+            "--profile",
+            "release",
+        ])
+        .assert();
+
+    let output = assert.success().get_output().clone();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        stdout.contains("WORKSPACE BUDGET REPORT"),
+        "expected report header, got: {stdout}"
+    );
+    assert!(stdout.contains("mock-contract-a"), "got: {stdout}");
+    assert!(stdout.contains("mock-contract-b"), "got: {stdout}");
+    assert!(stdout.contains("CPU Instructions"), "got: {stdout}");
+    assert!(stdout.contains("1,000,000 inst."), "got: {stdout}");
+}
+
+#[test]
+fn profile_flag_invalid_profile_fails_build() {
+    let workspace = setup_mock_workspace();
+
+    let assert = budget_report_cmd(workspace.path())
+        .args([
+            "budget-report",
+            "--network",
+            "local",
+            "--source",
+            "alice",
+            "--profile",
+            "nonexistent-profile",
+        ])
+        .assert();
+
+    let output = assert.failure().get_output().clone();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        stderr.contains("Failed to build") || stderr.contains("error"),
+        "stderr should indicate a build failure with the invalid profile, got: {stderr:?}"
+    );
+}


### PR DESCRIPTION
Add a `--profile` flag to `BudgetReportArgs` that lets users specify a custom Cargo build profile (e.g. `release-opt`) instead of the hardcoded `--release`. Defaults to `release` when not provided.

Closes #16.