### PR TITLE
Add record/replay mode for offline budget report generation

### DIFF
--- a/cargo-budget-report/src/fixture.rs
+++ b/cargo-budget-report/src/fixture.rs
@@ -1,0 +1,46 @@
+use anyhow::{Context, Result};
+use std::collections::HashMap;
+use std::path::Path;
+
+pub const FIXTURE_VERSION: u32 = 1;
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct FixtureFile {
+    pub fixture_version: u32,
+    pub entries: HashMap<String, serde_json::Value>,
+}
+
+impl FixtureFile {
+    #[allow(dead_code)]
+    pub fn new() -> Self {
+        FixtureFile {
+            fixture_version: FIXTURE_VERSION,
+            entries: HashMap::new(),
+        }
+    }
+
+    pub fn load(path: impl AsRef<Path>) -> Result<Self> {
+        let content = std::fs::read_to_string(path.as_ref())
+            .with_context(|| format!("Failed to read fixture file: {}", path.as_ref().display()))?;
+        let fixture: FixtureFile = serde_json::from_str(&content).with_context(|| {
+            format!("Failed to parse fixture file: {}", path.as_ref().display())
+        })?;
+        if fixture.fixture_version != FIXTURE_VERSION {
+            anyhow::bail!(
+                "Fixture version mismatch: expected {} got {}",
+                FIXTURE_VERSION,
+                fixture.fixture_version
+            );
+        }
+        Ok(fixture)
+    }
+
+    pub fn save(&self, path: impl AsRef<Path>) -> Result<()> {
+        let content =
+            serde_json::to_string_pretty(self).context("Failed to serialize fixture file")?;
+        std::fs::write(path.as_ref(), content).with_context(|| {
+            format!("Failed to write fixture file: {}", path.as_ref().display())
+        })?;
+        Ok(())
+    }
+}

--- a/cargo-budget-report/src/live.rs
+++ b/cargo-budget-report/src/live.rs
@@ -1,0 +1,101 @@
+use crate::transport::Transport;
+use anyhow::{Context, Result};
+use serde_json::Value;
+use std::io::Write;
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+pub struct LiveTransport;
+
+impl Transport for LiveTransport {
+    fn deploy_contract(
+        &mut self,
+        wasm_path: &Path,
+        source: &str,
+        network: &str,
+        _package_name: &str,
+    ) -> Result<String> {
+        let output = Command::new("stellar")
+            .args([
+                "contract",
+                "deploy",
+                "--wasm",
+                wasm_path.to_str().context("wasm path is not valid UTF-8")?,
+                "--source",
+                source,
+                "--network",
+                network,
+            ])
+            .output()
+            .context("failed to execute stellar-cli deploy")?;
+
+        if output.status.success() {
+            let contract_id = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            Ok(contract_id)
+        } else {
+            let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+            anyhow::bail!("stellar contract deploy failed: {}", stderr)
+        }
+    }
+
+    fn build_invoke_xdr(
+        &mut self,
+        contract_id: &str,
+        source: &str,
+        network: &str,
+        function: &str,
+        func_args: &[String],
+        _package: &str,
+    ) -> Result<String> {
+        let invoke_args =
+            crate::build_invoke_args(contract_id, source, network, function, func_args);
+        let output = Command::new("stellar")
+            .args(&invoke_args)
+            .output()
+            .context("failed to execute stellar-cli invoke")?;
+
+        if output.status.success() {
+            Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+        } else {
+            let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+            anyhow::bail!("stellar invoke failed: {}", stderr)
+        }
+    }
+
+    fn simulate_transaction(
+        &mut self,
+        b64_xdr: &str,
+        _package: &str,
+        _function: &str,
+    ) -> Result<Value> {
+        let rpc_payload = crate::build_rpc_payload(b64_xdr);
+
+        let mut curl = Command::new("curl")
+            .args([
+                "-s",
+                "-X",
+                "POST",
+                "-H",
+                "Content-Type: application/json",
+                "-d",
+                "@-",
+                "https://soroban-testnet.stellar.org:443",
+            ])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+            .context("failed to execute curl")?;
+
+        {
+            let stdin = curl.stdin.as_mut().context("Failed to open stdin")?;
+            stdin
+                .write_all(rpc_payload.to_string().as_bytes())
+                .context("Failed to write to stdin")?;
+        }
+
+        let curl_output = curl
+            .wait_with_output()
+            .context("Failed to read curl output")?;
+        serde_json::from_slice(&curl_output.stdout).context("Failed to parse RPC response")
+    }
+}

--- a/cargo-budget-report/src/record.rs
+++ b/cargo-budget-report/src/record.rs
@@ -1,0 +1,80 @@
+use crate::fixture::FixtureFile;
+use crate::transport::Transport;
+use anyhow::Result;
+use serde_json::Value;
+use std::collections::HashMap;
+use std::path::Path;
+
+pub struct RecordingTransport<T: Transport> {
+    inner: T,
+    entries: HashMap<String, serde_json::Value>,
+}
+
+impl<T: Transport> RecordingTransport<T> {
+    pub fn new(inner: T) -> Self {
+        RecordingTransport {
+            inner,
+            entries: HashMap::new(),
+        }
+    }
+
+    pub fn into_fixture(self) -> FixtureFile {
+        FixtureFile {
+            fixture_version: crate::fixture::FIXTURE_VERSION,
+            entries: self.entries,
+        }
+    }
+}
+
+impl<T: Transport> Transport for RecordingTransport<T> {
+    fn deploy_contract(
+        &mut self,
+        wasm_path: &Path,
+        source: &str,
+        network: &str,
+        package_name: &str,
+    ) -> Result<String> {
+        let result = self
+            .inner
+            .deploy_contract(wasm_path, source, network, package_name)?;
+        let key = format!("deploy:{}", package_name);
+        self.entries.insert(key, Value::String(result.clone()));
+        Ok(result)
+    }
+
+    fn build_invoke_xdr(
+        &mut self,
+        contract_id: &str,
+        source: &str,
+        network: &str,
+        function: &str,
+        func_args: &[String],
+        package: &str,
+    ) -> Result<String> {
+        let result = self.inner.build_invoke_xdr(
+            contract_id,
+            source,
+            network,
+            function,
+            func_args,
+            package,
+        )?;
+        let key = format!("invoke:{}:{}", package, function);
+        self.entries.insert(key, Value::String(result.clone()));
+        Ok(result)
+    }
+
+    fn simulate_transaction(
+        &mut self,
+        b64_xdr: &str,
+        package: &str,
+        function: &str,
+    ) -> Result<Value> {
+        let result = self
+            .inner
+            .simulate_transaction(b64_xdr, package, function)?;
+        let key = format!("simulate:{}:{}", package, function);
+        self.entries.insert(key, result.clone());
+        Ok(result)
+    }
+}

--- a/cargo-budget-report/src/replay.rs
+++ b/cargo-budget-report/src/replay.rs
@@ -1,0 +1,63 @@
+use crate::fixture::FixtureFile;
+use crate::transport::Transport;
+use anyhow::{Context, Result};
+use serde_json::Value;
+use std::collections::HashMap;
+use std::path::Path;
+
+pub struct ReplayTransport {
+    entries: HashMap<String, serde_json::Value>,
+}
+
+impl ReplayTransport {
+    pub fn new(fixture: FixtureFile) -> Self {
+        ReplayTransport {
+            entries: fixture.entries,
+        }
+    }
+}
+
+impl Transport for ReplayTransport {
+    fn deploy_contract(
+        &mut self,
+        _wasm_path: &Path,
+        _source: &str,
+        _network: &str,
+        package_name: &str,
+    ) -> Result<String> {
+        let key = format!("deploy:{}", package_name);
+        self.entries
+            .get(&key)
+            .and_then(|v| v.as_str().map(String::from))
+            .with_context(|| format!("Fixture not found for deploy:{}", package_name))
+    }
+
+    fn build_invoke_xdr(
+        &mut self,
+        _contract_id: &str,
+        _source: &str,
+        _network: &str,
+        function: &str,
+        _func_args: &[String],
+        package: &str,
+    ) -> Result<String> {
+        let key = format!("invoke:{}:{}", package, function);
+        self.entries
+            .get(&key)
+            .and_then(|v| v.as_str().map(String::from))
+            .with_context(|| format!("Fixture not found for invoke:{}:{}", package, function))
+    }
+
+    fn simulate_transaction(
+        &mut self,
+        _b64_xdr: &str,
+        package: &str,
+        function: &str,
+    ) -> Result<Value> {
+        let key = format!("simulate:{}:{}", package, function);
+        self.entries
+            .get(&key)
+            .cloned()
+            .with_context(|| format!("Fixture not found for simulate:{}:{}", package, function))
+    }
+}

--- a/cargo-budget-report/src/transport.rs
+++ b/cargo-budget-report/src/transport.rs
@@ -1,0 +1,30 @@
+use anyhow::Result;
+use serde_json::Value;
+use std::path::Path;
+
+pub trait Transport {
+    fn deploy_contract(
+        &mut self,
+        wasm_path: &Path,
+        source: &str,
+        network: &str,
+        package_name: &str,
+    ) -> Result<String>;
+
+    fn build_invoke_xdr(
+        &mut self,
+        contract_id: &str,
+        source: &str,
+        network: &str,
+        function: &str,
+        func_args: &[String],
+        package: &str,
+    ) -> Result<String>;
+
+    fn simulate_transaction(
+        &mut self,
+        b64_xdr: &str,
+        package: &str,
+        function: &str,
+    ) -> Result<Value>;
+}

--- a/cargo-budget-report/tests/replay_e2e.rs
+++ b/cargo-budget-report/tests/replay_e2e.rs
@@ -1,0 +1,276 @@
+//! End-to-end tests for replay mode.
+//!
+//! These tests verify that the replay system can reproduce the entire
+//! reporting pipeline using recorded fixtures without any network access
+//! or external binaries (stellar CLI, curl).
+//!
+//! The test uses the same mock workspace as the live integration tests but
+//! runs with --replay instead of --network/--source, so deploy, invoke,
+//! and RPC calls are served from a pre-recorded fixture file instead of
+//! the fake_bin scripts.
+
+use assert_cmd::Command;
+use predicates::str::contains;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn manifest_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn mock_workspace_fixture() -> PathBuf {
+    manifest_dir().join("tests/fixtures/mock_workspace")
+}
+
+/// Recursively copies `src` into `dst`, creating `dst` if needed.
+fn copy_dir_all(src: &Path, dst: &Path) {
+    fs::create_dir_all(dst).expect("failed to create destination directory");
+    for entry in fs::read_dir(src).expect("failed to read source directory") {
+        let entry = entry.expect("failed to read directory entry");
+        let file_type = entry.file_type().expect("failed to read file type");
+        let dst_path = dst.join(entry.file_name());
+        if file_type.is_dir() {
+            copy_dir_all(&entry.path(), &dst_path);
+        } else {
+            fs::copy(entry.path(), &dst_path).expect("failed to copy fixture file");
+        }
+    }
+}
+
+/// Copies the mock workspace fixture into a fresh tempdir and returns it.
+fn setup_mock_workspace() -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().expect("failed to create tempdir");
+    copy_dir_all(&mock_workspace_fixture(), tmp.path());
+    tmp
+}
+
+/// The replay fixture used by every test in this module.
+///
+/// Contains deterministic responses that match what the fake_bin scripts
+/// produce: contract IDs for both mock contracts, invoke XDR, and
+/// simulateTransaction responses that decode to instructions=1000000,
+/// read_bytes=2048, write_bytes=4096.
+const REPLAY_FIXTURE_JSON: &str = r#"{
+  "fixture_version": 1,
+  "entries": {
+    "deploy:mock-contract-a": "CAMOCKCONTRACTIDAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    "deploy:mock-contract-b": "CAMOCKCONTRACTIDAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    "invoke:mock-contract-a:ping": "AAAAAgAAAAA=",
+    "invoke:mock-contract-b:pong": "AAAAAgAAAAA=",
+    "simulate:mock-contract-a:ping": {
+      "jsonrpc": "2.0",
+      "id": 1,
+      "result": {
+        "transactionData": "AAAAAAAAAAAAAAAAAA9CQAAACAAAABAAAAAAAAAAAAA=",
+        "minResourceFee": "1000"
+      }
+    },
+    "simulate:mock-contract-b:pong": {
+      "jsonrpc": "2.0",
+      "id": 1,
+      "result": {
+        "transactionData": "AAAAAAAAAAAAAAAAAA9CQAAACAAAABAAAAAAAAAAAAA=",
+        "minResourceFee": "1000"
+      }
+    }
+  }
+}"#;
+
+/// Builds a ready-to-run `Command` for the compiled `cargo-budget-report`
+/// binary, with its cwd set to `dir`. No PATH manipulation is needed
+/// because replay mode does not shell out to `stellar` or `curl`.
+fn budget_report_cmd(dir: &Path) -> Command {
+    let mut cmd = Command::cargo_bin("cargo-budget-report").expect("binary should be built");
+    cmd.current_dir(dir);
+    cmd
+}
+
+#[test]
+fn replay_produces_identical_table_report() {
+    let workspace = setup_mock_workspace();
+    let fixture_path = workspace.path().join("replay_fixtures.json");
+    fs::write(&fixture_path, REPLAY_FIXTURE_JSON).expect("failed to write fixture file");
+
+    let assert = budget_report_cmd(workspace.path())
+        .args([
+            "budget-report",
+            "--replay",
+            "--fixtures",
+            fixture_path.to_str().unwrap(),
+        ])
+        .assert();
+
+    let output = assert.success().get_output().clone();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // Verify the same report structure as the live integration test.
+    assert!(
+        stdout.contains("WORKSPACE BUDGET REPORT"),
+        "expected report header, got: {stdout}"
+    );
+    assert!(stdout.contains("mock-contract-a"), "got: {stdout}");
+    assert!(stdout.contains("mock-contract-b"), "got: {stdout}");
+    assert!(stdout.contains("CPU Instructions"), "got: {stdout}");
+    assert!(stdout.contains("1,000,000 inst."), "got: {stdout}");
+    assert!(stdout.contains("2,048 B"), "got: {stdout}");
+    assert!(stdout.contains("4,096 B"), "got: {stdout}");
+}
+
+#[test]
+fn replay_produces_identical_json_report() {
+    let workspace = setup_mock_workspace();
+    let fixture_path = workspace.path().join("replay_fixtures.json");
+    fs::write(&fixture_path, REPLAY_FIXTURE_JSON).expect("failed to write fixture file");
+
+    let assert = budget_report_cmd(workspace.path())
+        .args([
+            "budget-report",
+            "--replay",
+            "--fixtures",
+            fixture_path.to_str().unwrap(),
+            "--json",
+        ])
+        .assert();
+
+    let output = assert.success().get_output().clone();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let reports: serde_json::Value =
+        serde_json::from_str(&stdout).expect("stdout should be valid JSON");
+    let reports = reports.as_array().expect("report should be a JSON array");
+
+    let packages: std::collections::HashSet<&str> = reports
+        .iter()
+        .map(|r| r["package"].as_str().expect("package should be a string"))
+        .collect();
+    assert!(packages.contains("mock-contract-a"), "got: {reports:?}");
+    assert!(packages.contains("mock-contract-b"), "got: {reports:?}");
+
+    let cpu_entry = reports
+        .iter()
+        .find(|r| r["package"] == "mock-contract-a" && r["metric"] == "CPU Instructions")
+        .expect("CPU Instructions entry for mock-contract-a should be present");
+    assert_eq!(cpu_entry["value"], 1_000_000);
+
+    let wasm_bytes_entry = reports
+        .iter()
+        .find(|r| r["package"] == "mock-contract-b" && r["metric"] == "WASM Bytes")
+        .expect("WASM Bytes entry for mock-contract-b should be present");
+    assert!(
+        wasm_bytes_entry["value"].as_u64().unwrap_or(0) > 0,
+        "got: {wasm_bytes_entry:?}"
+    );
+}
+
+#[test]
+fn replay_with_check_passes_when_limits_match() {
+    let workspace = setup_mock_workspace();
+    let fixture_path = workspace.path().join("replay_fixtures.json");
+    fs::write(&fixture_path, REPLAY_FIXTURE_JSON).expect("failed to write fixture file");
+
+    fs::write(
+        workspace.path().join("budget.toml"),
+        "[functions.ping]\n\
+         cpu_limit = 5000000\n\
+         read_limit = 5000\n\
+         write_limit = 5000\n\
+         \n\
+         [functions.pong]\n\
+         cpu_limit = 5000000\n\
+         read_limit = 5000\n\
+         write_limit = 5000\n",
+    )
+    .expect("failed to write budget.toml");
+
+    let assert = budget_report_cmd(workspace.path())
+        .args([
+            "budget-report",
+            "--replay",
+            "--fixtures",
+            fixture_path.to_str().unwrap(),
+            "--check",
+        ])
+        .assert();
+
+    let output = assert.success().get_output().clone();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("=== BUDGET CHECKS ==="), "got: {stdout}");
+    assert!(
+        stdout.contains("Summary: 6 check(s) passed, 0 failed"),
+        "got: {stdout}"
+    );
+}
+
+#[test]
+fn replay_with_check_fails_when_limit_exceeded() {
+    let workspace = setup_mock_workspace();
+    let fixture_path = workspace.path().join("replay_fixtures.json");
+    fs::write(&fixture_path, REPLAY_FIXTURE_JSON).expect("failed to write fixture file");
+
+    fs::write(
+        workspace.path().join("budget.toml"),
+        "[functions.ping]\n\
+         cpu_limit = 10\n\
+         \n\
+         [functions.pong]\n\
+         cpu_limit = 5000000\n",
+    )
+    .expect("failed to write budget.toml");
+
+    let mut cmd = budget_report_cmd(workspace.path());
+    cmd.args([
+        "budget-report",
+        "--replay",
+        "--fixtures",
+        fixture_path.to_str().unwrap(),
+        "--check",
+    ]);
+
+    cmd.assert()
+        .failure()
+        .stdout(contains("mock-contract-a::ping [CPU Instructions]"))
+        .stdout(contains("FAIL"));
+}
+
+#[test]
+fn replay_refuses_to_run_without_fixture() {
+    let workspace = setup_mock_workspace();
+
+    let assert = budget_report_cmd(workspace.path())
+        .args(["budget-report", "--replay"])
+        .assert();
+
+    let output = assert.failure().get_output().clone();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Failed to read fixture file"),
+        "expected fixture error, got: {stderr}"
+    );
+}
+
+#[test]
+fn replay_mode_does_not_require_mocked_binaries() {
+    let workspace = setup_mock_workspace();
+    let fixture_path = workspace.path().join("replay_fixtures.json");
+    fs::write(&fixture_path, REPLAY_FIXTURE_JSON).expect("failed to write fixture file");
+
+    // Run with the real PATH (no fake_bin prepended).  Replay mode never
+    // invokes `stellar` or `curl`, so the real binaries (or their absence)
+    // are irrelevant — the pipeline succeeds from recorded data alone.
+    let assert = Command::cargo_bin("cargo-budget-report")
+        .expect("binary should be built")
+        .current_dir(workspace.path())
+        .args([
+            "budget-report",
+            "--replay",
+            "--fixtures",
+            fixture_path.to_str().unwrap(),
+        ])
+        .assert();
+
+    let output = assert.success().get_output().clone();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("WORKSPACE BUDGET REPORT"),
+        "replay should work without fake_bin or stellar/curl on PATH, got: {stdout}"
+    );
+}


### PR DESCRIPTION
Closes #150

## Summary

Introduces a record/replay subsystem that enables `cargo-budget-report` to execute its full reporting pipeline deterministically without requiring network access.

## Changes

- Added a transport abstraction for all external RPC and subprocess interactions.
- Preserved the existing live execution path as the default behavior.
- Added `--record` mode to capture external responses into versioned fixtures.
- Added `--replay`/`--offline` mode to execute the complete reporting pipeline using recorded fixtures.
- Ensured replay produces the same report as the original recorded execution.
- Documented the fixture format and the process for refreshing recorded fixtures.

## Testing

Added an end-to-end replay test that:

- loads recorded fixtures
- runs the full discover → build → simulate → decode → report pipeline
- verifies the generated report matches the expected output

## Documentation

Updated documentation with:

- record mode usage
- replay mode usage
- fixture structure
- fixture refresh workflow
- guidance for deterministic CI using replay instead of mocked output

## Validation

Successfully ran:

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

The live workflow remains unchanged, while replay mode enables deterministic offline execution suitable for CI.