### PR TITLE
ci(release): publish crates to crates.io and attach checksums to GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,13 +4,32 @@ on:
   push:
     tags:
       - "v*"
+  pull_request:
+    branches: ["main"]
 
 permissions:
   contents: write
 
 jobs:
-  release:
-    name: Build and Release
+  publish-dry-run:
+    name: Dry Run Publish Check
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7.0.1
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Dry run budget-macros
+        run: cargo publish -p budget-macros --dry-run
+
+      - name: Dry run cargo-budget-report
+        run: cargo publish -p cargo-budget-report --dry-run
+
+  build:
+    name: Build
+    if: github.event_name == 'push'
     strategy:
       matrix:
         include:
@@ -52,7 +71,62 @@ jobs:
         shell: bash
         run: cp target/${{ matrix.target }}/release/${{ matrix.bin }} ${{ matrix.name }}
 
+      - name: Upload Build Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.name }}
+          path: ${{ matrix.name }}
+
+  checksums:
+    name: Generate Checksums
+    needs: build
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7.0.1
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: cargo-budget-report-*
+          merge-multiple: true
+
+      - name: Generate SHA256SUMS
+        run: sha256sum cargo-budget-report-* > SHA256SUMS
+
       - name: Release
         uses: softprops/action-gh-release@v3
         with:
-          files: ${{ matrix.name }}
+          files: |
+            cargo-budget-report-*
+            SHA256SUMS
+
+  publish:
+    name: Publish to crates.io
+    needs: build
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7.0.1
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Verify tag version matches crate versions
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          WORKSPACE_VERSION=$(awk '/^\[workspace\.package\]/ {found=1} found && /^version = / {print; exit}' Cargo.toml | sed 's/.*= "\(.*\)"/\1/')
+          if [ "$TAG_VERSION" != "$WORKSPACE_VERSION" ]; then
+            echo "ERROR: Tag v$TAG_VERSION does not match workspace version $WORKSPACE_VERSION"
+            exit 1
+          fi
+          echo "Workspace version $WORKSPACE_VERSION matches tag v$TAG_VERSION"
+
+      - name: Publish budget-macros
+        run: cargo publish -p budget-macros
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Publish cargo-budget-report
+        run: cargo publish -p cargo-budget-report
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -80,7 +80,13 @@ Example: `https://your-org.github.io/your-repo/dashboard.html?limit=100`.
 ## 🚀 Quick Start
 
 ### 1. Installation
-Install the CLI tool locally from the repository root:
+
+Install from [crates.io](https://crates.io/crates/cargo-budget-report) (recommended):
+```bash
+cargo install cargo-budget-report
+```
+
+Alternatively, build from source:
 ```bash
 cargo install --path cargo-budget-report
 ```

--- a/budget-macros/Cargo.toml
+++ b/budget-macros/Cargo.toml
@@ -6,6 +6,8 @@ description = "Proc-macro crate providing budget assertion attributes for Soroba
 license.workspace = true
 repository.workspace = true
 readme.workspace = true
+keywords = ["soroban", "stellar", "testing", "budget", "proc-macro"]
+categories = ["development-tools::testing", "development-tools::procedural-macro-helpers"]
 
 [lib]
 proc-macro = true

--- a/cargo-budget-report/Cargo.toml
+++ b/cargo-budget-report/Cargo.toml
@@ -6,6 +6,8 @@ description = "Cargo subcommand that reports Soroban smart-contract resource cos
 license.workspace = true
 repository.workspace = true
 readme.workspace = true
+keywords = ["soroban", "stellar", "testing", "budget", "cargo-subcommand"]
+categories = ["development-tools::cargo-plugins", "development-tools::testing"]
 
 [dependencies]
 clap = { version = "4.4", features = ["derive"] }

--- a/cargo-budget-report/src/main.rs
+++ b/cargo-budget-report/src/main.rs
@@ -1651,4 +1651,210 @@ write_limit = 1000
         let csv = reports_to_csv(&reports, false);
         assert_eq!(csv, "package,function,metric,value\n");
     }
+
+    // ── JSON serialization tests ────────────────────────────────────────
+
+    /// Helper to serialize a slice of CostReport to a pretty-printed JSON
+    /// string, matching the `--json` output path.
+    fn reports_to_json(reports: &[CostReport]) -> String {
+        serde_json::to_string_pretty(reports).unwrap()
+    }
+
+    #[test]
+    fn json_output_without_check_has_package_function_metric_value() {
+        let reports = vec![
+            CostReport {
+                package: "my-contract".to_string(),
+                function: "do_work".to_string(),
+                metric: "CPU Instructions",
+                value: Some(1_000_000),
+                limit: None,
+                pass: None,
+            },
+            CostReport {
+                package: "my-contract".to_string(),
+                function: "do_work".to_string(),
+                metric: "Read Bytes",
+                value: Some(2_048),
+                limit: None,
+                pass: None,
+            },
+        ];
+        let json = reports_to_json(&reports);
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let arr = parsed.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+
+        assert_eq!(arr[0]["package"], "my-contract");
+        assert_eq!(arr[0]["function"], "do_work");
+        assert_eq!(arr[0]["metric"], "CPU Instructions");
+        assert_eq!(arr[0]["value"], 1_000_000);
+        assert!(arr[0].get("limit").is_none());
+        assert!(arr[0].get("pass").is_none());
+
+        assert_eq!(arr[1]["package"], "my-contract");
+        assert_eq!(arr[1]["function"], "do_work");
+        assert_eq!(arr[1]["metric"], "Read Bytes");
+        assert_eq!(arr[1]["value"], 2_048);
+        assert!(arr[1].get("limit").is_none());
+        assert!(arr[1].get("pass").is_none());
+    }
+
+    #[test]
+    fn json_output_with_check_includes_limit_and_pass() {
+        let reports = vec![
+            CostReport {
+                package: "my-contract".to_string(),
+                function: "do_work".to_string(),
+                metric: "CPU Instructions",
+                value: Some(1_000_000),
+                limit: Some(5_000_000),
+                pass: Some(true),
+            },
+            CostReport {
+                package: "my-contract".to_string(),
+                function: "do_work".to_string(),
+                metric: "Write Bytes",
+                value: Some(4_096),
+                limit: Some(1_000),
+                pass: Some(false),
+            },
+        ];
+        let json = reports_to_json(&reports);
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let arr = parsed.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+
+        assert_eq!(arr[0]["package"], "my-contract");
+        assert_eq!(arr[0]["function"], "do_work");
+        assert_eq!(arr[0]["metric"], "CPU Instructions");
+        assert_eq!(arr[0]["value"], 1_000_000);
+        assert_eq!(arr[0]["limit"], 5_000_000);
+        assert_eq!(arr[0]["pass"], true);
+
+        assert_eq!(arr[1]["package"], "my-contract");
+        assert_eq!(arr[1]["function"], "do_work");
+        assert_eq!(arr[1]["metric"], "Write Bytes");
+        assert_eq!(arr[1]["value"], 4_096);
+        assert_eq!(arr[1]["limit"], 1_000);
+        assert_eq!(arr[1]["pass"], false);
+    }
+
+    #[test]
+    fn json_output_without_check_excludes_null_values() {
+        let reports = vec![
+            CostReport {
+                package: "my-contract".to_string(),
+                function: "do_work".to_string(),
+                metric: "CPU Instructions",
+                value: None,
+                limit: None,
+                pass: None,
+            },
+            CostReport {
+                package: "my-contract".to_string(),
+                function: "do_work".to_string(),
+                metric: "Read Bytes",
+                value: Some(2_048),
+                limit: None,
+                pass: None,
+            },
+        ];
+        let json = reports_to_json(&reports);
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let arr = parsed.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+
+        // The CPU Instructions entry has value: None; with
+        // skip_serializing_if, "value" is absent from the JSON object.
+        assert!(arr[0].get("value").is_none());
+        // But the entry itself is still present in the array.
+        assert_eq!(arr[0]["metric"], "CPU Instructions");
+
+        assert_eq!(arr[1]["metric"], "Read Bytes");
+        assert_eq!(arr[1]["value"], 2_048);
+    }
+
+    #[test]
+    fn json_output_with_check_includes_simulation_failures() {
+        let reports = vec![CostReport {
+            package: "my-contract".to_string(),
+            function: "do_work".to_string(),
+            metric: "CPU Instructions",
+            value: None,
+            limit: Some(5_000_000),
+            pass: Some(false),
+        }];
+        let json = reports_to_json(&reports);
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let arr = parsed.as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+
+        assert_eq!(arr[0]["package"], "my-contract");
+        assert_eq!(arr[0]["function"], "do_work");
+        assert_eq!(arr[0]["metric"], "CPU Instructions");
+        assert!(arr[0].get("value").is_none());
+        assert_eq!(arr[0]["limit"], 5_000_000);
+        assert_eq!(arr[0]["pass"], false);
+    }
+
+    #[test]
+    fn json_output_empty_reports_produces_empty_array() {
+        let reports: Vec<CostReport> = vec![];
+        let json = reports_to_json(&reports);
+        assert_eq!(json, "[]");
+    }
+
+    #[test]
+    fn json_output_with_all_metric_types() {
+        let reports = vec![
+            CostReport {
+                package: "pkg".to_string(),
+                function: "f".to_string(),
+                metric: "CPU Instructions",
+                value: Some(1_000_000),
+                limit: None,
+                pass: None,
+            },
+            CostReport {
+                package: "pkg".to_string(),
+                function: "f".to_string(),
+                metric: "Read Bytes",
+                value: Some(2_048),
+                limit: None,
+                pass: None,
+            },
+            CostReport {
+                package: "pkg".to_string(),
+                function: "f".to_string(),
+                metric: "Write Bytes",
+                value: Some(4_096),
+                limit: None,
+                pass: None,
+            },
+            CostReport {
+                package: "pkg".to_string(),
+                function: "f".to_string(),
+                metric: "WASM Bytes",
+                value: Some(12_345),
+                limit: None,
+                pass: None,
+            },
+        ];
+        let json = reports_to_json(&reports);
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let arr = parsed.as_array().unwrap();
+        assert_eq!(arr.len(), 4);
+
+        let metrics: Vec<&str> = arr.iter().map(|r| r["metric"].as_str().unwrap()).collect();
+        assert_eq!(
+            metrics,
+            vec![
+                "CPU Instructions",
+                "Read Bytes",
+                "Write Bytes",
+                "WASM Bytes"
+            ]
+        );
+    }
 }


### PR DESCRIPTION
## Description

Adds the metadata and CI infrastructure needed to publish `budget-macros` and `cargo-budget-report` to crates.io, and attaches SHA256 checksums to GitHub releases.

## Changes

### `Cargo.toml` metadata
- **`budget-macros/Cargo.toml`** — Added `keywords` and `categories` (required by crates.io)
- **`cargo-budget-report/Cargo.toml`** — Added `keywords` and `categories` (required by crates.io)
- **`amm-pool-contract/Cargo.toml`** — Already has `publish = false`, no change needed

### CI (`.github/workflows/release.yml`)
- **Dry-run on PRs**: New `publish-dry-run` job runs `cargo publish --dry-run` for both crates on every PR
- **Checksums**: New `checksums` job downloads all build artifacts, generates `SHA256SUMS`, and attaches it to the release
- **Publish**: New `publish` job verifies the tag version matches the workspace version, then runs `cargo publish -p budget-macros` followed by `cargo publish -p cargo-budget-report`, authenticated via `CARGO_REGISTRY_TOKEN` secret

### Documentation
- **`README.md`** — Updated Quick Start: `cargo install cargo-budget-report` (crates.io) as primary path, `--path` kept as from-source alternative

## Verification
- `cargo fmt --all -- --check` — passed
- `cargo clippy --workspace --all-targets -- -D warnings` — passed
- `cargo test --workspace` — 151/152 pass (1 pre-existing failure unrelated to these changes)

## `cargo publish --dry-run` output

### budget-macros
```
$ cargo publish -p budget-macros --dry-run
   Packaging budget-macros v0.1.0
   Verifying budget-macros v0.1.0
   Compiling proc-macro2 v1.0.106
   Compiling unicode-ident v1.0.24
   Compiling quote v1.0.46
   Compiling syn v2.0.118
   Compiling serde_json v1.0.150
   Compiling budget-macros v0.1.0
   Uploading budget-macros v0.1.0
warning: aborting upload due to dry run
```

### cargo-budget-report
```
$ cargo publish -p cargo-budget-report --dry-run
   Packaging cargo-budget-report v0.1.0
   Verifying cargo-budget-report v0.1.0
   Compiling ... (72 crates)
   Compiling cargo-budget-report v0.1.0
   Uploading cargo-budget-report v0.1.0
warning: aborting upload due to dry run
```

Closes #27