### PR TITLE
fix: repair broken main (parser aliasing bug, non-exhaustive match, revert destructive #300)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1613,6 +1613,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
+name = "soroban-budget-assert-core"
+version = "0.1.0"
+
+[[package]]
 name = "soroban-builtin-sdk-macros"
 version = "22.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,7 +300,6 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "serde_json",
  "syn 2.0.118",
  "trybuild",
 ]

--- a/amm-pool-contract/tests/budget_test.rs
+++ b/amm-pool-contract/tests/budget_test.rs
@@ -3,7 +3,7 @@
 use std::sync::{Mutex, PoisonError};
 
 use amm_pool_contract::{ConstantProductPool, ConstantProductPoolClient};
-use budget_macros::{budget_cpu_lt, budget_lt, budget_mem_lt};
+use budget_macros::{budget_cpu_lt, budget_lt, budget_mem_lt, budget_write_bytes_lt};
 use soroban_sdk::{testutils::Address as _, Address, Env};
 
 /// Serialises all JSON-config tests so they never read stale `budget.json`

--- a/budget-macros/Cargo.toml
+++ b/budget-macros/Cargo.toml
@@ -14,7 +14,6 @@ proc-macro = true
 syn = { version = "2.0", features = ["full", "extra-traits", "visit-mut"] }
 quote = "1.0"
 proc-macro2 = "1.0"
-serde_json = "1.0"
 
 [dev-dependencies]
 trybuild = "1.0"

--- a/budget-macros/src/lib.rs
+++ b/budget-macros/src/lib.rs
@@ -73,12 +73,15 @@ impl Parse for BudgetLimit {
             // tokens for other spec keys (`cpu`, `mem`, `env_ident`).
             // Only consume key=value pairs whose key is a known
             // BudgetLimit key; stop before anything else.
+            // `fork()`, not `clone()`: `ParseStream` is `&ParseBuffer`, so
+            // cloning the reference aliases the same buffer and the
+            // "lookahead" parse below would consume from the real stream.
             if input.peek(Token![,]) {
-                let ahead = input.clone();
+                let ahead = input.fork();
                 let _ = ahead.parse::<Token![,]>();
                 if !(ahead.peek(Ident)
                     && matches!(
-                        ahead.clone().parse::<Ident>().unwrap().to_string().as_str(),
+                        ahead.fork().parse::<Ident>().unwrap().to_string().as_str(),
                         "env" | "env_file" | "config"
                     ))
                 {
@@ -86,7 +89,7 @@ impl Parse for BudgetLimit {
                 }
                 input.parse::<Token![,]>()?;
             } else if input.peek(Ident) {
-                let ahead = input.clone();
+                let ahead = input.fork();
                 let key: Ident = ahead.parse().unwrap();
                 if !matches!(key.to_string().as_str(), "env" | "env_file" | "config") {
                     break;
@@ -499,28 +502,7 @@ pub fn budget_write_bytes_lt(attr: TokenStream, item: TokenStream) -> TokenStrea
 
     let stmts = &input_fn.block.stmts;
 
-    let limit_expr = match limit {
-        BudgetLimit::Int(n) => quote! { #n },
-        BudgetLimit::EnvVar(var) => quote! {
-            std::env::var(#var)
-                .ok()
-                .and_then(|s| s.parse().ok())
-                .unwrap_or(u64::MAX)
-        },
-        BudgetLimit::Config(key) => quote! {
-            std::fs::read_to_string(std::path::Path::new("budget.json"))
-                .ok()
-                .map(|content| {
-                    parse_config_value(&content, #key).unwrap_or_else(|| {
-                        panic!(
-                            "budget_write_bytes_lt: key '{}' not found or invalid in budget.json",
-                            #key,
-                        )
-                    })
-                })
-                .unwrap_or(u64::MAX)
-        },
-    };
+    let limit_expr = generate_limit_expr(&limit, "budget_write_bytes_lt");
 
     let env_ident = proc_macro2::Ident::new("env", proc_macro2::Span::call_site());
 

--- a/cargo-budget-report/Cargo.toml
+++ b/cargo-budget-report/Cargo.toml
@@ -1,22 +1,26 @@
 [package]
 name = "cargo-budget-report"
-version = "0.1.0"
-edition = "2021"
-publish = false
-
-[[bin]]
-name = "cargo-budget-report"
-path = "src/main.rs"
+version.workspace = true
+edition.workspace = true
+description = "Cargo subcommand that reports Soroban smart-contract resource costs across a workspace."
+license.workspace = true
+repository.workspace = true
+readme.workspace = true
 
 [dependencies]
-anyhow = "1"
-cargo_metadata = "0.18"
-clap = { version = "4", features = ["derive"] }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+clap = { version = "4.4", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+tabled = "0.14"
+stellar-xdr = { version = "22.1.0", features = ["std", "base64", "serde"] }
+anyhow = "1.0.103"
 toml = "0.8"
-walkdir = "2"
+cargo_metadata = "0.18"
+wasmparser = "0.116.1"
+indicatif = "0.17.8"
+csv = "1.3"
 
 [dev-dependencies]
-assert_cmd = "2"
-predicates = "3"
+tempfile = "3.10"
+assert_cmd = "2.0"
+predicates = "3.1"

--- a/cargo-budget-report/src/main.rs
+++ b/cargo-budget-report/src/main.rs
@@ -1692,9 +1692,9 @@ fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-mod module_4;
-mod module_3;
 mod module_2;
+mod module_3;
+mod module_4;
 pub mod validate;
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/cargo-budget-report/src/main.rs
+++ b/cargo-budget-report/src/main.rs
@@ -1345,15 +1345,36 @@ fn main() -> anyhow::Result<()> {
                         }
                     }
                 }
-
-                let contents = fs::read_to_string(&entry_path).with_context(|| {
-                    format!("failed to read snapshot {}", entry_path.display())
-                })?;
-                let snapshot: Snapshot = serde_json::from_str(&contents).with_context(|| {
-                    format!("failed to parse snapshot {}", entry_path.display())
-                })?;
-                snapshots.push(snapshot);
             }
+        }
+
+        if exported_fns.is_empty() {
+            if !args.quiet {
+                eprintln!("No exported functions found in {}", package.name);
+            }
+            continue;
+        }
+
+        let spinner = if args.quiet {
+            None
+        } else {
+            let pb = ProgressBar::new_spinner();
+            pb.set_style(
+                ProgressStyle::default_spinner()
+                    .tick_strings(&["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏", "✔"])
+                    .template("{spinner:.green} Deploying contract {msg}...")
+                    .unwrap(),
+            );
+            pb.set_message(package.name.to_string());
+            pb.enable_steady_tick(std::time::Duration::from_millis(100));
+            Some(pb)
+        };
+
+        let contract_id =
+            deploy_contract_with_retry(wasm_path.as_std_path(), &source, &network, &package.name)?;
+
+        if let Some(spinner) = spinner {
+            spinner.finish_and_clear();
         }
 
         eprintln!("Contract deployed at: {}", contract_id);
@@ -1491,8 +1512,8 @@ fn main() -> anyhow::Result<()> {
         if has_errors || (args.check && checks_failed) || validation_failed {
             std::process::exit(1);
         }
+        return Ok(());
     }
-}
 
     // Per-function tolerance overrides from `budget.toml` (top-level plus
     // per-function). Built once so Mode::Check (baseline regression) and the
@@ -2265,32 +2286,274 @@ write_limit = 1000
     // --- Cost value formatter tests ---
 
     #[test]
-    fn json_output_has_the_versioned_report_schema() {
-        let report = BudgetReport {
-            schema_version: 1,
-            snapshots: vec![Snapshot {
-                name: "transfer".to_owned(),
-                cpu: 123,
-                memory: 456,
-            }],
-        };
-
-        let value: serde_json::Value =
-            serde_json::from_str(&report.render(OutputFormat::Json).unwrap()).unwrap();
-
-        assert_eq!(value["schema_version"], 1);
-        assert_eq!(value["snapshots"][0]["name"], "transfer");
-        assert_eq!(value["snapshots"][0]["cpu"], 123);
-        assert_eq!(value["snapshots"][0]["memory"], 456);
+    fn formatter_zero_cpu() {
         assert_eq!(
-            value.as_object().unwrap().keys().collect::<Vec<_>>(),
-            vec!["schema_version", "snapshots"]
+            format_with_commas_and_units(0, "CPU Instructions"),
+            "0 inst."
         );
     }
 
     #[test]
-    fn json_is_selected_by_the_format_flag() {
-        let cli = Cli::try_parse_from(["cargo-budget-report", "--format", "json"]).unwrap();
-        assert_eq!(cli.format, OutputFormat::Json);
+    fn formatter_zero_bytes() {
+        assert_eq!(format_with_commas_and_units(0, "Read Bytes"), "0 B");
+    }
+
+    #[test]
+    fn formatter_single_digit_cpu() {
+        assert_eq!(
+            format_with_commas_and_units(7, "CPU Instructions"),
+            "7 inst."
+        );
+    }
+
+    #[test]
+    fn formatter_single_digit_bytes() {
+        assert_eq!(format_with_commas_and_units(3, "Write Bytes"), "3 B");
+    }
+
+    #[test]
+    fn formatter_just_below_thousand() {
+        assert_eq!(
+            format_with_commas_and_units(999, "CPU Instructions"),
+            "999 inst."
+        );
+    }
+
+    #[test]
+    fn formatter_at_thousand() {
+        assert_eq!(
+            format_with_commas_and_units(1_000, "CPU Instructions"),
+            "1,000 inst."
+        );
+    }
+
+    #[test]
+    fn formatter_just_above_thousand() {
+        assert_eq!(
+            format_with_commas_and_units(1_001, "CPU Instructions"),
+            "1,001 inst."
+        );
+    }
+
+    #[test]
+    fn formatter_just_below_million() {
+        assert_eq!(
+            format_with_commas_and_units(999_999, "Read Bytes"),
+            "999,999 B"
+        );
+    }
+
+    #[test]
+    fn formatter_at_million() {
+        assert_eq!(
+            format_with_commas_and_units(1_000_000, "CPU Instructions"),
+            "1,000,000 inst."
+        );
+    }
+
+    #[test]
+    fn formatter_just_above_million() {
+        assert_eq!(
+            format_with_commas_and_units(1_000_001, "Write Bytes"),
+            "1,000,001 B"
+        );
+    }
+
+    #[test]
+    fn formatter_ten_million() {
+        assert_eq!(
+            format_with_commas_and_units(10_000_000, "CPU Instructions"),
+            "10,000,000 inst."
+        );
+    }
+
+    #[test]
+    fn formatter_u32_max_cpu() {
+        assert_eq!(
+            format_with_commas_and_units(u64::from(u32::MAX), "CPU Instructions"),
+            "4,294,967,295 inst."
+        );
+    }
+
+    #[test]
+    fn formatter_u32_max_bytes() {
+        assert_eq!(
+            format_with_commas_and_units(u64::from(u32::MAX), "Read Bytes"),
+            "4,294,967,295 B"
+        );
+    }
+
+    #[test]
+    fn formatter_write_bytes_gets_byte_unit() {
+        assert_eq!(
+            format_with_commas_and_units(4_096, "Write Bytes"),
+            "4,096 B"
+        );
+    }
+
+    #[test]
+    fn formatter_non_bytes_metric_gets_inst_unit() {
+        assert_eq!(
+            format_with_commas_and_units(500, "Some Other Metric"),
+            "500 inst."
+        );
+    }
+
+    // --- CSV serialization tests ---
+
+    /// Helper to serialize a slice of CostReport to CSV bytes and return the
+    /// result as a String, using the same logic as the `--csv` output path.
+    fn reports_to_csv(reports: &[CostReport], check: bool) -> String {
+        let mut csv_writer = csv::Writer::from_writer(vec![]);
+        if check {
+            csv_writer
+                .write_record(["package", "function", "metric", "value", "limit", "pass"])
+                .unwrap();
+            for report in reports {
+                let value_str = report.value.map(|val| val.to_string()).unwrap_or_default();
+                let limit_str = report.limit.map(|lim| lim.to_string()).unwrap_or_default();
+                let pass_str = report.pass.map(|p| p.to_string()).unwrap_or_default();
+                csv_writer
+                    .write_record([
+                        report.package.as_str(),
+                        report.function.as_str(),
+                        report.metric,
+                        value_str.as_str(),
+                        limit_str.as_str(),
+                        pass_str.as_str(),
+                    ])
+                    .unwrap();
+            }
+        } else {
+            csv_writer
+                .write_record(["package", "function", "metric", "value"])
+                .unwrap();
+            for report in reports {
+                if report.value.is_some() {
+                    let value_str = report.value.map(|val| val.to_string()).unwrap_or_default();
+                    csv_writer
+                        .write_record([
+                            report.package.as_str(),
+                            report.function.as_str(),
+                            report.metric,
+                            value_str.as_str(),
+                        ])
+                        .unwrap();
+                }
+            }
+        }
+        csv_writer.flush().unwrap();
+        String::from_utf8(csv_writer.into_inner().unwrap()).unwrap()
+    }
+
+    #[test]
+    fn csv_output_without_check_has_four_columns() {
+        let reports = vec![
+            CostReport {
+                package: "my-contract".to_string(),
+                function: "do_work".to_string(),
+                metric: "CPU Instructions",
+                value: Some(1_000_000),
+                limit: None,
+                pass: None,
+            },
+            CostReport {
+                package: "my-contract".to_string(),
+                function: "do_work".to_string(),
+                metric: "Read Bytes",
+                value: Some(2_048),
+                limit: None,
+                pass: None,
+            },
+        ];
+        let csv = reports_to_csv(&reports, false);
+        let expected = concat!(
+            "package,function,metric,value\n",
+            "my-contract,do_work,CPU Instructions,1000000\n",
+            "my-contract,do_work,Read Bytes,2048\n",
+        );
+        assert_eq!(csv, expected);
+    }
+
+    #[test]
+    fn csv_output_with_check_has_six_columns() {
+        let reports = vec![
+            CostReport {
+                package: "my-contract".to_string(),
+                function: "do_work".to_string(),
+                metric: "CPU Instructions",
+                value: Some(1_000_000),
+                limit: Some(5_000_000),
+                pass: Some(true),
+            },
+            CostReport {
+                package: "my-contract".to_string(),
+                function: "do_work".to_string(),
+                metric: "Write Bytes",
+                value: Some(4_096),
+                limit: Some(1_000),
+                pass: Some(false),
+            },
+        ];
+        let csv = reports_to_csv(&reports, true);
+        let expected = concat!(
+            "package,function,metric,value,limit,pass\n",
+            "my-contract,do_work,CPU Instructions,1000000,5000000,true\n",
+            "my-contract,do_work,Write Bytes,4096,1000,false\n",
+        );
+        assert_eq!(csv, expected);
+    }
+
+    #[test]
+    fn csv_output_without_check_excludes_null_values() {
+        let reports = vec![
+            CostReport {
+                package: "my-contract".to_string(),
+                function: "do_work".to_string(),
+                metric: "CPU Instructions",
+                value: None,
+                limit: None,
+                pass: None,
+            },
+            CostReport {
+                package: "my-contract".to_string(),
+                function: "do_work".to_string(),
+                metric: "Read Bytes",
+                value: Some(2_048),
+                limit: None,
+                pass: None,
+            },
+        ];
+        let csv = reports_to_csv(&reports, false);
+        let expected = concat!(
+            "package,function,metric,value\n",
+            "my-contract,do_work,Read Bytes,2048\n",
+        );
+        assert_eq!(csv, expected);
+    }
+
+    #[test]
+    fn csv_output_with_check_includes_simulation_failures() {
+        let reports = vec![CostReport {
+            package: "my-contract".to_string(),
+            function: "do_work".to_string(),
+            metric: "CPU Instructions",
+            value: None,
+            limit: Some(5_000_000),
+            pass: Some(false),
+        }];
+        let csv = reports_to_csv(&reports, true);
+        let expected = concat!(
+            "package,function,metric,value,limit,pass\n",
+            "my-contract,do_work,CPU Instructions,,5000000,false\n",
+        );
+        assert_eq!(csv, expected);
+    }
+
+    #[test]
+    fn csv_output_empty_reports_produces_header_only() {
+        let reports: Vec<CostReport> = vec![];
+        let csv = reports_to_csv(&reports, false);
+        assert_eq!(csv, "package,function,metric,value\n");
     }
 }


### PR DESCRIPTION
## Why

`main` currently fails **both** required checks and does not compile, so **no PR in this repo can merge** until this lands. This was found while triaging the open PR backlog.

## Root causes (all pre-existing on `main`)

1. **`budget-macros` parser aliasing bug.** `BudgetLimit::parse` used `input.clone()` for lookahead. `ParseStream` is `&ParseBuffer`, so cloning the *reference* aliases the same buffer — the "lookahead" parse consumed from the real stream. Every `env_file = IDENT` attribute failed with `expected identifier` pointing at the `=`, including this crate's own `tests/ui/pass/pass_env_file.rs` which is asserted to compile. Switched to `fork()`.

2. **Non-exhaustive match.** `budget_write_bytes_lt` carried a stale inline copy of the limit-expression match that never gained a `BudgetLimit::EnvFile` arm → `E0004`. Replaced with the canonical `generate_limit_expr()` helper that already handles all four variants (also removes ~20 lines of duplication).

3. **Missing import.** `budget_test.rs` uses `#[budget_write_bytes_lt]` without importing it.

4. **Revert of 82bbb32** (`Fix: feat: add JSON output mode ... (Auto-Generated)`, #300). That commit deleted 310 lines — contract deployment, the progress spinner, ~270 lines of tests — spliced in unrelated snapshot-reading code, and left an unbalanced brace that closed `fn main()` early.

## Result

| Check | Before | After |
|---|---|---|
| `cargo fmt --all -- --check` | fail | **pass** |
| `cargo clippy --workspace --all-targets -- -D warnings` | fail | **pass** |
| `cargo test --workspace` | does not compile | **19 pass / 12 fail** |

`Code Quality` should go green. `budget-check` will still fail on the remaining 12.

## Follow-up needed (deliberately not in this PR)

The 12 remaining failures are **budget-threshold calibration**, not logic bugs — e.g. `test_budget_wasm` measures 3,115,838 CPU against a 900,000 limit. `tier-a-limits.env` describes itself as a hand-composed fixture to be replaced by `cargo budget-report --derive-limits` against a real Tier B report. Two others (`test_storage_read_wasm_local`, `test_measure_gap_vs_input_size`) fail with `HostError: Error(WasmVm, InvalidAction)`. Setting those numbers is a maintainer judgement call, so I've left them.

Regenerated `test_snapshots/*.json` were deliberately excluded — committing them would mask regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TBuZPYykPjk7Tko2sJ6KHN