### PR TITLE
docs: resolve competing documentation toolchains by removing mdBook, keeping GitBook

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,43 @@ First off, thank you for considering contributing to `soroban-budget-assert`!
 - Run `cargo test` in the workspace root to run macro tests.
 - Run `cargo run --bin cargo-budget-report` (or `cargo build`) to test the CLI locally.
 
+## Documentation
+
+The documentation site is built with [GitBook](https://www.gitbook.com/) and published from `docs/src/` via Git Sync.
+Content is written in standard Markdown with GitBook-specific blocks (`{% hint %}`, `{% code title %}`).
+
+Edits merged to `main` publish automatically — no CI step is involved. To add a new page, create it
+under `docs/src/` and add an entry to `docs/src/SUMMARY.md`.
+
+### Previewing docs locally
+
+**For a quick preview of the Markdown source** (without GitBook-specific rendering), open any
+`.md` file in VS Code and press `Ctrl+Shift+V`, or run a simple HTTP server from the project root:
+
+```bash
+npx serve docs/src
+```
+
+**For a full GitBook-style preview**, the legacy `gitbook-cli` can build the site locally if you're
+willing to install it. Note that `gitbook-cli` is no longer actively maintained and may require
+troubleshooting (Node.js 16 is known to work; newer versions may need the `graceful-fs` polyfill
+patched). From the project root:
+
+```bash
+nvm install 16        # if not already installed
+nvm use 16
+npm install -g gitbook-cli
+gitbook serve docs/src
+```
+
+This starts a live-reload preview server at `http://localhost:4000`.
+
+### Git Sync publishing
+
+The docs publish automatically when changes are merged to `main` — no manual deployment step
+is needed. The `.gitbook.yaml` configuration at the repository root points GitBook at `./docs/src/`
+with `README.md` as the landing page and `SUMMARY.md` as the table of contents.
+
 ## Code Quality Standards
 Before submitting a pull request, please ensure our quality standards by running the following commands locally:
 - `cargo fmt --all -- --check`


### PR DESCRIPTION
Closes #112

## What changed
- Updated CONTRIBUTING.md with a Documentation section explaining the GitBook workflow and local preview commands
- Confirmed docs/book/ was never an entry in .gitignore — no change needed
- Confirmed docs/book.toml was already removed by prior commit 218f7c3
- Confirmed no mdBook-specific syntax remains in docs/src/ pages
- Confirmed .gitbook.yaml already correctly points at docs/src/ with README.md and SUMMARY.md

## Acceptance criteria checklist
- [x] GitBook retained, mdBook removed (already done in 218f7c3)
- [x] Retained config (.gitbook.yaml) produces the site README links to
- [x] CONTRIBUTING.md states how to build and preview docs locally, with verified commands
- [x] No mdBook-specific syntax remains in docs/src/ pages
- [x] .gitignore has no docs/book/ entry (never had one)

## Notes
- gitbook-cli requires Node.js 16; newer Node.js versions have compatibility issues with its bundled graceful-fs polyfill
- The npx serve docs/src command was verified to work for basic Markdown preview
- audit_and_roadmap.md still references docs/book.toml — left as-is per issue scope