### PR TITLE
ci: fix invalid YAML indentation in budget.yml

### DIFF
--- a/.github/workflows/budget.yml
+++ b/.github/workflows/budget.yml
@@ -81,7 +81,7 @@ jobs:
     - name: Download Budget Report
       uses: actions/download-artifact@v4
       with:
-name: budget-report
+        name: budget-report
 
     - name: Record History Dataset
       run: |


### PR DESCRIPTION
`.github/workflows/budget.yml` was unparseable — the `name: budget-report` key under the Download Budget Report step's `with:` block had lost its indentation (line 84).

Because `budget-check` is a **required** status check and the workflow could never be parsed, GitHub never reported that context. Every PR in this repo was therefore permanently BLOCKED regardless of its content.

Validated with `yaml.safe_load` — all five workflow files now parse, and `budget.yml` exposes jobs `budget-check` and `record-history` as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TBuZPYykPjk7Tko2sJ6KHN