### PR TITLE
refactor: abstract CLI argument parsing into a dedicated module

### DIFF
--- a/cargo-budget-report/src/cli.rs
+++ b/cargo-budget-report/src/cli.rs
@@ -1,0 +1,145 @@
+use clap::Parser;
+
+/// Top-level CLI entry point for `cargo budget-report`.
+///
+/// Wraps the binary in a `cargo <subcommand>` compatible enum so it can be
+/// invoked as `cargo budget-report [OPTIONS]`.
+#[derive(Parser, Debug)]
+#[command(name = "cargo", bin_name = "cargo")]
+pub enum CargoCli {
+    BudgetReport(BudgetReportArgs),
+}
+
+/// CLI arguments for `cargo budget-report`.
+///
+/// All fields are optional; missing values fall back to the corresponding
+/// `budget.toml` configuration when available.
+#[derive(Parser, Debug)]
+pub struct BudgetReportArgs {
+    /// Scaffold a commented `budget.toml` template and exit.
+    #[arg(long)]
+    pub init: bool,
+
+    /// Allow `--init` to overwrite an existing `budget.toml`.
+    #[arg(long)]
+    pub force: bool,
+
+    #[arg(long)]
+    pub network: Option<String>,
+
+    #[arg(long)]
+    pub source: Option<String>,
+
+    #[arg(long, default_value_t = false)]
+    pub json: bool,
+
+    /// Enforce per-function limits declared in `budget.toml`.
+    ///
+    /// When set, each measured metric is compared against its configured
+    /// `cpu_limit` / `read_limit` / `write_limit`. A missing limit means the
+    /// metric is reported but **not** enforced. The process exits with a
+    /// non-zero status when any limit is breached, or when a function that
+    /// has a `budget.toml` entry fails to simulate. Functions that are not
+    /// declared in `budget.toml` are reported only.
+    #[arg(long, default_value_t = false)]
+    pub check: bool,
+
+    /// Emit the report as CSV instead of a table or JSON.
+    #[arg(long, default_value_t = false)]
+    pub csv: bool,
+
+    /// Write a new resource-usage baseline snapshot to this path and exit.
+    #[arg(long)]
+    pub record_baseline: Option<String>,
+
+    /// Check current measurements against an existing baseline snapshot at
+    /// this path, applying the configured regression tolerance.
+    #[arg(long)]
+    pub check_baseline: Option<String>,
+
+    /// Override the regression tolerance (e.g. "0.10" for 10%). Takes
+    /// precedence over `tolerance` in `budget.toml`.
+    #[arg(long)]
+    pub tolerance: Option<String>,
+
+    /// Suppress non-essential progress messages and warnings on stderr.
+    ///
+    /// The final report (table, JSON, or CSV) is still printed to stdout.
+    /// Fatal errors from child-process spawn failures or hard contract
+    /// build failures are not suppressed — they always go to stderr
+    /// regardless of this flag.
+    #[arg(long, default_value_t = false)]
+    pub quiet: bool,
+
+    /// Validate reported metrics against the Stellar CLI's own XDR decoder.
+    ///
+    /// For each successfully simulated function, the base64 SorobanTransactionData
+    /// XDR from the RPC response is re-decoded through `stellar xdr decode` and
+    /// the resulting metrics are compared against cargo-budget-report's values.
+    /// Any discrepancy is reported as a diagnostic; the tool still exits with a
+    /// non-zero status when mismatches are found.
+    ///
+    /// Validation is skipped (not failed) when the Stellar CLI or the `xdr decode`
+    /// subcommand is unavailable.
+    #[arg(long, default_value_t = false)]
+    pub validate: bool,
+
+    /// Cargo build profile to use when compiling the contract WASM.
+    ///
+    /// Defaults to `release` when not provided. Custom profiles (e.g.
+    /// `release-opt`) must be defined in the project's `Cargo.toml`.
+    #[arg(long)]
+    pub profile: Option<String>,
+
+    /// Derive local (Tier A) test limits from a Tier B JSON report and
+    /// exit. Reads the Tier B report from `--from <PATH>` (or stdin if
+    /// `--from -`) and writes the chosen `KEY=VALUE` shape to the file
+    /// at `<OUT>`.
+    ///
+    /// The Tier B report is the same JSON shape `cargo budget-report
+    /// --json` emits — either the bare array of `CostReport`-shaped
+    /// rows or the `{schema_version, snapshots}` wrapped form. The
+    /// `--margin-{cpu,memory,read,write}` flags (or the `[margin]`
+    /// section of `budget.toml`) supply the per-metric multipliers
+    /// applied to the Tier B values; the resulting ceilings become
+    /// Tier A test limits.
+    ///
+    /// The function-to-scenario mapping is recorded under
+    /// `[[scenarios.<name>]]` blocks in `budget.toml` so component
+    /// limits can be summed under a single Tier A `KEY=VALUE` for
+    /// tests that exercise multi-step workflows.
+    #[arg(long, value_name = "OUT")]
+    pub derive_limits: Option<String>,
+
+    /// Source Tier B JSON report for `--derive-limits`. Use `-` to
+    /// read JSON from stdin (so `cargo budget-report --json | cargo
+    /// budget-report --derive-limits tier-a-limits.env` composes).
+    #[arg(long, value_name = "PATH")]
+    pub from: Option<String>,
+
+    /// Per-metric multiplier applied to Tier B CPU values. Required
+    /// unless `[margin].cpu_margin` is set in `budget.toml`; no
+    /// default is applied because the project deliberately treats the
+    /// margin as data (issue #45) and silently picking a value would
+    /// defeat the audit trail.
+    #[arg(long, value_name = "F")]
+    pub margin_cpu: Option<String>,
+
+    /// Per-metric multiplier applied to Tier B memory values.
+    #[arg(long, value_name = "F")]
+    pub margin_memory: Option<String>,
+
+    /// Per-metric multiplier applied to Tier B read-bytes values.
+    #[arg(long, value_name = "F")]
+    pub margin_read: Option<String>,
+
+    /// Per-metric multiplier applied to Tier B write-bytes values.
+    #[arg(long, value_name = "F")]
+    pub margin_write: Option<String>,
+
+    /// Path to write the Markdown provenance table next to the env
+    /// file. Defaults to `<OUT>` with `.env` replaced by `.md` (e.g.
+    /// `tier-a-limits.provenance.md` for `tier-a-limits.env`).
+    #[arg(long, value_name = "PATH")]
+    pub provenance_out: Option<String>,
+}

--- a/cargo-budget-report/src/main.rs
+++ b/cargo-budget-report/src/main.rs
@@ -1,6 +1,8 @@
+use crate::cli::{BudgetReportArgs, CargoCli};
 use crate::derive::{DerivationConfig, Margin};
 use crate::module_10::{Error, Result, SimulationFailure, SimulationOutcome};
 use anyhow::Context;
+mod cli;
 mod compare;
 use cargo_metadata::MetadataCommand;
 use clap::Parser;
@@ -69,150 +71,6 @@ cpu_limit = 5000000
 read_limit = 5000
 write_limit = 1000
 "#;
-
-/// Top-level CLI entry point for `cargo budget-report`.
-///
-/// Wraps the binary in a `cargo <subcommand>` compatible enum so it can be
-/// invoked as `cargo budget-report [OPTIONS]`.
-#[derive(Parser, Debug)]
-#[command(name = "cargo", bin_name = "cargo")]
-enum CargoCli {
-    BudgetReport(BudgetReportArgs),
-}
-
-/// CLI arguments for `cargo budget-report`.
-///
-/// All fields are optional; missing values fall back to the corresponding
-/// `budget.toml` configuration when available.
-#[derive(Parser, Debug)]
-struct BudgetReportArgs {
-    /// Scaffold a commented `budget.toml` template and exit.
-    #[arg(long)]
-    init: bool,
-
-    /// Allow `--init` to overwrite an existing `budget.toml`.
-    #[arg(long)]
-    force: bool,
-
-    #[arg(long)]
-    network: Option<String>,
-
-    #[arg(long)]
-    source: Option<String>,
-
-    #[arg(long, default_value_t = false)]
-    json: bool,
-
-    /// Enforce per-function limits declared in `budget.toml`.
-    ///
-    /// When set, each measured metric is compared against its configured
-    /// `cpu_limit` / `read_limit` / `write_limit`. A missing limit means the
-    /// metric is reported but **not** enforced. The process exits with a
-    /// non-zero status when any limit is breached, or when a function that
-    /// has a `budget.toml` entry fails to simulate. Functions that are not
-    /// declared in `budget.toml` are reported only.
-    #[arg(long, default_value_t = false)]
-    check: bool,
-
-    /// Emit the report as CSV instead of a table or JSON.
-    #[arg(long, default_value_t = false)]
-    csv: bool,
-
-    /// Write a new resource-usage baseline snapshot to this path and exit.
-    #[arg(long)]
-    record_baseline: Option<String>,
-
-    /// Check current measurements against an existing baseline snapshot at
-    /// this path, applying the configured regression tolerance.
-    #[arg(long)]
-    check_baseline: Option<String>,
-
-    /// Override the regression tolerance (e.g. "0.10" for 10%). Takes
-    /// precedence over `tolerance` in `budget.toml`.
-    #[arg(long)]
-    tolerance: Option<String>,
-
-    /// Suppress non-essential progress messages and warnings on stderr.
-    ///
-    /// The final report (table, JSON, or CSV) is still printed to stdout.
-    /// Fatal errors from child-process spawn failures or hard contract
-    /// build failures are not suppressed — they always go to stderr
-    /// regardless of this flag.
-    #[arg(long, default_value_t = false)]
-    quiet: bool,
-
-    /// Validate reported metrics against the Stellar CLI's own XDR decoder.
-    ///
-    /// For each successfully simulated function, the base64 SorobanTransactionData
-    /// XDR from the RPC response is re-decoded through `stellar xdr decode` and
-    /// the resulting metrics are compared against cargo-budget-report's values.
-    /// Any discrepancy is reported as a diagnostic; the tool still exits with a
-    /// non-zero status when mismatches are found.
-    ///
-    /// Validation is skipped (not failed) when the Stellar CLI or the `xdr decode`
-    /// subcommand is unavailable.
-    #[arg(long, default_value_t = false)]
-    validate: bool,
-
-    /// Cargo build profile to use when compiling the contract WASM.
-    ///
-    /// Defaults to `release` when not provided. Custom profiles (e.g.
-    /// `release-opt`) must be defined in the project's `Cargo.toml`.
-    #[arg(long)]
-    profile: Option<String>,
-
-    /// Derive local (Tier A) test limits from a Tier B JSON report and
-    /// exit. Reads the Tier B report from `--from <PATH>` (or stdin if
-    /// `--from -`) and writes the chosen `KEY=VALUE` shape to the file
-    /// at `<OUT>`.
-    ///
-    /// The Tier B report is the same JSON shape `cargo budget-report
-    /// --json` emits — either the bare array of `CostReport`-shaped
-    /// rows or the `{schema_version, snapshots}` wrapped form. The
-    /// `--margin-{cpu,memory,read,write}` flags (or the `[margin]`
-    /// section of `budget.toml`) supply the per-metric multipliers
-    /// applied to the Tier B values; the resulting ceilings become
-    /// Tier A test limits.
-    ///
-    /// The function-to-scenario mapping is recorded under
-    /// `[[scenarios.<name>]]` blocks in `budget.toml` so component
-    /// limits can be summed under a single Tier A `KEY=VALUE` for
-    /// tests that exercise multi-step workflows.
-    #[arg(long, value_name = "OUT")]
-    derive_limits: Option<String>,
-
-    /// Source Tier B JSON report for `--derive-limits`. Use `-` to
-    /// read JSON from stdin (so `cargo budget-report --json | cargo
-    /// budget-report --derive-limits tier-a-limits.env` composes).
-    #[arg(long, value_name = "PATH")]
-    from: Option<String>,
-
-    /// Per-metric multiplier applied to Tier B CPU values. Required
-    /// unless `[margin].cpu_margin` is set in `budget.toml`; no
-    /// default is applied because the project deliberately treats the
-    /// margin as data (issue #45) and silently picking a value would
-    /// defeat the audit trail.
-    #[arg(long, value_name = "F")]
-    margin_cpu: Option<String>,
-
-    /// Per-metric multiplier applied to Tier B memory values.
-    #[arg(long, value_name = "F")]
-    margin_memory: Option<String>,
-
-    /// Per-metric multiplier applied to Tier B read-bytes values.
-    #[arg(long, value_name = "F")]
-    margin_read: Option<String>,
-
-    /// Per-metric multiplier applied to Tier B write-bytes values.
-    #[arg(long, value_name = "F")]
-    margin_write: Option<String>,
-
-    /// Path to write the Markdown provenance table next to the env
-    /// file. Defaults to `<OUT>` with `.env` replaced by `.md` (e.g.
-    /// `tier-a-limits.provenance.md` for `tier-a-limits.env`).
-    #[arg(long, value_name = "PATH")]
-    provenance_out: Option<String>,
-}
 
 /// Top-level configuration deserialized from `budget.toml`.
 ///


### PR DESCRIPTION
- Move CargoCli and BudgetReportArgs from main.rs to new cli.rs module
- Update main.rs to import and use the new cli module
- Fix syntax error (premature closing brace) in main.rs
- Apply cargo fmt formatting fixes

Closes #[this issue]

## Description
<!-- Describe your changes in detail -->

## Related Issue
<!-- If this PR addresses an existing issue, please link it here. -->
Closes #

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
- [ ] Added/Updated tests
- [ ] Passed `cargo test`
- [ ] Passed `cargo clippy`
- [ ] Formatted with `cargo fmt`
- [ ] Reviewed or re-measured budget limits in `amm-pool-contract/tests/budget_test.rs` when contract, build profile, or toolchain changes may affect them

## Types of changes
<!-- What types of changes does your code introduce? -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update


closes #73