### PR TITLE
fix(cargo-budget-report): repair the mock stellar CLI test fixture

### DIFF
--- a/cargo-budget-report/tests/fixtures/fake_bin/stellar
+++ b/cargo-budget-report/tests/fixtures/fake_bin/stellar
@@ -16,7 +16,8 @@ FAIL_COUNT_FILE="${MOCK_STELLAR_FAIL_COUNT_FILE:-}"
 case "${1:-}" in
   --version)
     echo "stellar-cli 0.0.0-mock"
-    ;;    contract)
+    ;;
+  contract)
     case "${2:-}" in
       deploy)
         if [ "$FAIL_COUNT" -gt 0 ] && [ -n "$FAIL_COUNT_FILE" ]; then
@@ -33,12 +34,15 @@ case "${1:-}" in
         # Generate a deterministic contract ID based on the WASM path
         # (the last `--wasm` argument), so different contracts get
         # different IDs for cross-contract testing.
+        # Scan a copy of the positional parameters rather than shifting them:
+        # shifting inside a `for ... in "$@"` loop runs `shift` more times than
+        # there are arguments, and the resulting non-zero exit trips `set -e`.
         WASM_PATH=""
-        for i in "$@"; do
-            case "$i" in
-                --wasm) shift; WASM_PATH="$1";;
-            esac
-            shift
+        args=("$@")
+        for idx in "${!args[@]}"; do
+            if [ "${args[$idx]}" = "--wasm" ]; then
+                WASM_PATH="${args[$((idx + 1))]:-}"
+            fi
         done
         case "$WASM_PATH" in
             *mock_callee*)
@@ -58,53 +62,6 @@ case "${1:-}" in
                 ;;
         esac
         ;;
-      invoke)
-        # Real output is a base64 XDR transaction envelope. Its content is
-        # opaque to cargo-budget-report (it's forwarded verbatim to the RPC
-        # `simulateTransaction` call), so any placeholder string is fine here
-        # since `curl` is also mocked below.
-        echo "AAAAAgAAAAA="
-        ;;
-      *)
-        echo "mock stellar: unsupported 'contract' subcommand: ${2:-}" >&2
-        exit 1
-        ;;
-    esac
-    ;;
-  xdr)
-    # Support `stellar xdr decode --type SorobanTransactionData --output json`
-    # for validation integration tests.
-    if [ "${2:-}" = "decode" ]; then
-        # Drain stdin (the base64 XDR piped in)
-        cat >/dev/null
-        # Output the JSON that the real CLI would produce when decoding the
-        # fixture XDR. The fixture XDR "AAAAAAAAAAAAAAAAAA9CQAAACAAAABAAAAAAAAAAAAA="
-        # decodes to instructions=1000000, read_bytes=2048, write_bytes=4096.
-        cat <<'XDRJSON'
-{
-  "ext": "V0",
-  "resources": {
-    "footprint": {
-      "read_only": [],
-      "read_write": []
-    },
-    "instructions": 1000000,
-    "read_bytes": 2048,
-    "write_bytes": 4096
-  },
-  "resource_fee": 0
-}
-XDRJSON
-    else
-        echo "mock stellar: unsupported 'xdr' subcommand: ${2:-}" >&2
-        exit 1
-    fi
-    ;;
-  *)
-    echo "mock stellar: unsupported command: ${1:-}" >&2
-    exit 1
-    ;;
-esac
       invoke)
         # Real output is a base64 XDR transaction envelope. Its content is
         # opaque to cargo-budget-report (it's forwarded verbatim to the RPC


### PR DESCRIPTION
## Summary

The mock `stellar` CLI at `cargo-budget-report/tests/fixtures/fake_bin/stellar` was broken in two independent ways, leaving all 6 `cargo-budget-report` integration tests failing.

Neither defect was caught by CI. The `Run Budget Macros Test (Tier A)` step runs `cargo test`, not `cargo test --workspace` — and because the repo root is itself a package (`soroban-budget-assert-core`), `cargo-budget-report` is never built or tested in CI at all. CI is green today and stays green with this change; these tests only run locally under `--workspace`.

## The two defects

**1. Conflict-marker damage from the mass PR merges.** The same pattern repaired in #372, in a file that repair missed. The `contract)` case label had been concatenated onto the `--version)` arm's `;;`, and the final 47 lines were a verbatim duplicate of the `invoke)` / `xdr)` arms appended *after* the closing `esac`. The script did not parse at all:

```
line 108: syntax error near unexpected token `)'
```

Fixed by removing the duplicated tail and putting `contract)` back on its own line.

I deliberately did **not** restore the pre-damage version at `79f1f79d`. That version is 82 lines and predates three real features that survive intact in the undamaged portion of the current file:
- the friendbot retry mechanism (`2522260`)
- the `xdr decode` validation support (#326)
- the cross-contract deterministic contract IDs (`cdac79b`)

**2. A latent `set -e` bug, present since `cdac79b`.** The `--wasm` parsing loop iterated `for i in "$@"` while calling `shift` inside the loop body, so `shift` ran more times than there were arguments. The failing `shift` tripped `set -euo pipefail`, so every mocked deploy exited 1 with no output — surfacing only as `Deploy attempt 1/4 failed` with an empty error string.

This one is not merge damage: the loop is byte-identical to how it landed in `cdac79b`, so the mock's deploy path has never worked. Replaced with an index scan over a copy of the positional parameters, preserving the documented "last `--wasm` wins" behaviour.

## Verification

```
cargo test -p cargo-budget-report --test integration
test result: ok. 6 passed; 0 failed
```

All five contract-ID branches dispatch correctly (`mock_contract_a`, `mock_contract_b`, `mock_callee`, `mock_contract_renamed`, and the generic fallback).

- `cargo-budget-report` integration: **0/6 → 6/6**
- Full workspace failures: **23 → 17**
- CI (`cargo test`): still green, 51 + 18 passing

The remaining 17 failures are the Tier A marginal-cost instantiation floor in `amm-pool-contract`, the `budget-macros` ui test, and one `derive::tests` fixture disagreement. All are unrelated to this change and are left alone here.

## Note

This is a prerequisite for switching the Tier A CI step to `--workspace`, which is what would make this class of bug visible in the first place. That switch is still blocked on the remaining 17 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)