### PR TITLE
ci: guard against committing dependencies or build output

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -15,6 +15,31 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # `scripts/node_modules` was committed and later untracked in d6cb2db,
+      # leaving ~1.7MB blobs such as stellar-sdk.js in history permanently —
+      # .gitignore does not retract what is already committed, and a clone
+      # downloads history. This repository got off lightly at 10MB; the sibling
+      # soroban-cost-linter reached a 252MB clone the same way. These checks run
+      # before the Rust setup so they fail in seconds.
+      - name: No dependency or build output committed
+        run: |
+          if tracked=$(git ls-files | grep -E '(^|/)(target|node_modules)/'); then
+            echo "::error::Build output or vendored dependencies are committed:"
+            echo "$tracked"
+            exit 1
+          fi
+
+      - name: No large files committed
+        run: |
+          # The largest legitimate tracked file is ~88KB, so 5MB is generous.
+          large=$(git ls-files -z | xargs -0 du -k | awk '$1 > 5120 {print $1" KB\t"$2}')
+          if [ -n "$large" ]; then
+            echo "::error::Tracked files over 5MB. History is permanent, so these"
+            echo "::error::would inflate every clone forever even if deleted later:"
+            echo "$large"
+            exit 1
+          fi
+
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:


### PR DESCRIPTION
## Investigation result: this repo is healthy

Following the 252MB clone problem found in soroban-cost-linter, I ran the same
investigation here. **This repository does not have that problem:**

| | soroban-budget-assert | soroban-cost-linter |
|---|---|---|
| GitHub size | **10 MB** | 252 MB |
| packfile | 3.57 MiB | 310 MiB |
| working tree | 1.4 MB / 156 files | 1.1 MB / 152 files |
| history vs tree | ~2.5× — normal | **>200×** |

No `target/` directory has ever been committed. Largest currently tracked file
is 88KB. **No remediation is needed**, and documenting a blobless clone here
would be noise — a full clone already takes a couple of seconds.

## But the same gap exists

History shows `scripts/node_modules` *was* committed and later untracked in
`d6cb2db`, leaving blobs like `stellar-sdk.js` (1.73MB), `stellar-sdk-no-axios.js`
(1.66MB) and `stellar-base.js` (1.24MB) in history permanently. `.gitignore` and
`git rm` stop future commits but do not retract what is already there.

That is the identical mistake that took cost-linter to 252MB — caught early here,
so the damage stayed small. Nothing prevented it in either repo: **no pre-commit
config, no size check in CI.**

## The guard

Two checks added to the existing `lint` job:

- any tracked path under `target/` or `node_modules/`
- any tracked file over 5MB (largest today is ~88KB, so wide headroom)

`lint` is **already a required status context** here, so unlike the sibling repo
this needs no aggregating job and no branch-protection change. The checks run
before the Rust toolchain setup, so they fail in seconds rather than after a
build.

Verified in both directions: passes on the current tree, and catches a planted
`scripts/node_modules/pkg/index.js` and a 6MB file. A guard nobody has seen fail
is not a guard.