### PR TITLE
ci: stop Dependabot bundling the three tracked migrations

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,25 @@ updates:
       dependencies:
         patterns:
           - "*"
+    ignore:
+      # These three are migrations tracked as their own issues, not routine bumps.
+      # Grouping them in with everything else is what left PR #375 unmergeable, and
+      # then reproduced the same failure in PR #385: one grouped PR carrying a
+      # five-major-version `soroban-sdk` jump, a `stellar-xdr` jump that removes the
+      # `curr` module `cargo-budget-report` depends on, and a `wasmparser` jump of
+      # well over a hundred minor versions across which the parsing API changed.
+      # When they land together a failure in any one of them cannot be attributed.
+      #
+      # Bump these manually, one migration per PR, via their issues:
+      #   #382 — soroban-sdk / stellar-xdr
+      #   #383 — wasmparser
+      #
+      # REMOVE THESE ENTRIES once #382 and #383 have landed, so routine updates
+      # resume. While they are here these three crates get no automated updates at
+      # all, security advisories included — watch them by hand until then.
+      - dependency-name: "soroban-sdk"
+      - dependency-name: "stellar-xdr"
+      - dependency-name: "wasmparser"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Description

`soroban-sdk`, `stellar-xdr` and `wasmparser` are migrations with their own issues — **#382** (soroban-sdk / stellar-xdr) and **#383** (wasmparser) — not routine version bumps. Dependabot currently groups every cargo dependency under one `patterns: ["*"]` group, which sweeps all three into the same weekly PR as everything else.

That is what left **PR #375** unmergeable, and **PR #385** has since reproduced it exactly. #385 is open right now, failing `lint` and `Dry Run Publish Check`, and carries:

| Crate | From | To |
|---|---|---|
| `soroban-sdk` | 22.0.11 | 27.0.5 |
| `stellar-xdr` | 22.1.0 | 28.0.0 |
| `wasmparser` | 0.116.1 | 0.256.0 |

…plus 11 unrelated updates that are probably fine and cannot be merged because they are stuck behind three migrations.

`stellar-xdr` 27+ removes the `curr` module `cargo-budget-report` depends on. `wasmparser` 0.116 → 0.256 crosses an API change in the export-section parsing the tool uses to decide which functions to simulate. #383 puts it plainly: bundling them "makes a failure in either impossible to attribute, which is the state PR #375 is in today."

This change stops the bundling so the weekly grouped PR can go green on the updates that are genuinely routine.

## What this changes

Adds an `ignore:` block to the cargo ecosystem entry listing the three crates, with a comment recording why the entries exist, which issues own the migrations, and that they must be removed afterwards.

Same convention `soroban-cost-linter` already uses — it ignores `clippy_utils` for an equivalent lockstep reason, with a comment explaining it.

## Trade-off, stated explicitly

While these entries are in place, **the three crates receive no automated updates at all, security advisories included.** That is the cost of the fix and it is called out in the file comment as well as here.

The alternative — ignoring only `version-update:semver-major` — does not work for `wasmparser`, which is a `0.x` crate where the breaking jump registers as a minor update. Given both migrations are actively tracked and expected to land, a full ignore with a removal note is the cleaner option, but say so if you would rather take the narrower one.

## Verification

- `.github/dependabot.yml` parses as valid YAML, and the parsed `ignore` list is exactly `["soroban-sdk", "stellar-xdr", "wasmparser"]`.
- Configuration only — no code, no CI workflow, no dependency actually changed. `Cargo.toml` and `Cargo.lock` are untouched.

## Follow-up

Once **#382** and **#383** have both landed, delete the `ignore:` block so normal updates resume. The comment in the file says this too, so it does not depend on this PR description being found later.

#382 and #383 are unaffected by this change — it only stops Dependabot re-proposing their bumps underneath them.

> **Note:** this sentence originally paired a closing keyword directly with an issue number, inside a negation ("does not close ..."). GitHub's linked-issue parser reads the keyword and ignores the negation, so it closed the soroban-sdk / stellar-xdr migration issue when this PR merged. That issue has been reopened, and the wording here now avoids putting any closing keyword next to an issue reference — including in this note.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cys6yRdswdWxct8J4TQ73F