### PR TITLE
ci: ignore cargo_metadata until #469 lands

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
         patterns:
           - "*"
     ignore:
-      # These three are migrations tracked as their own issues, not routine bumps.
+      # These four are migrations tracked as their own issues, not routine bumps.
       # Grouping them in with everything else is what left PR #375 unmergeable, and
       # then reproduced the same failure in PR #385: one grouped PR carrying a
       # five-major-version `soroban-sdk` jump, a `stellar-xdr` jump that removes the
@@ -20,13 +20,22 @@ updates:
       # Bump these manually, one migration per PR, via their issues:
       #   #382 — soroban-sdk / stellar-xdr
       #   #383 — wasmparser
+      #   #469 — cargo_metadata (0.18 -> 0.23 retypes `crate_types` to `CrateType`
+      #          and `package.name` to `PackageName`; both are load-bearing in the
+      #          workspace-discovery path in `main.rs`)
       #
-      # REMOVE THESE ENTRIES once #382 and #383 have landed, so routine updates
-      # resume. While they are here these three crates get no automated updates at
-      # all, security advisories included — watch them by hand until then.
+      # REMOVE EACH ENTRY as its issue lands, so routine updates resume. While an
+      # entry is here that crate gets no automated updates at all, security
+      # advisories included — watch them by hand until then.
+      #
+      # `toml` (0.8 -> 1.1) and `tabled` (0.14 -> 0.21) are also majors in this
+      # group. They are deliberately NOT ignored: nothing has shown them to be
+      # breaking yet. If one turns out to be, give it its own issue and its own
+      # entry rather than widening this list pre-emptively.
       - dependency-name: "soroban-sdk"
       - dependency-name: "stellar-xdr"
       - dependency-name: "wasmparser"
+      - dependency-name: "cargo_metadata"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Description

Follow-up to #467. That change stopped Dependabot bundling `soroban-sdk`, `stellar-xdr` and `wasmparser`, and the group regenerated as **PR #468** carrying 11 updates instead of 14 — correctly excluding all three.

#468 is still red, but now for a **single attributable reason**, which is what #467 was for: `cargo_metadata` 0.18.1 → 0.23.1 is itself a breaking change.

| `main.rs` | Error | Cause |
|---|---|---|
| 1130 | `E0308` | `.any(\|ct\| *ct == "cdylib")` — `crate_types` now yields `cargo_metadata::CrateType`, not `&str` |
| 1161 | `E0308` | the same comparison in the cdylib target lookup |
| 1264 | `E0308` | `.entry(package.name.clone())` — `package.name` is now `PackageName`, not `String` |

Both types are load-bearing. `MetadataCommand` at `main.rs:1110` produces the package list everything downstream iterates, and the cdylib lookup is how the tool decides which packages are contracts and where their wasm lands. A careless migration here does not crash — it quietly measures the wrong set of packages. That deserves its own PR with a before/after discovery comparison, which is **#469**.

## What this changes

Adds `cargo_metadata` to the cargo `ignore:` list on the same terms as the other three, and rewords the comment so removal is understood as **per-issue** rather than all at once.

## What this deliberately does not do

`toml` (0.8.23 → 1.1.3) and `tabled` (0.14.0 → 0.21.0) are also majors in the same group. **They are not ignored**, and the comment says so explicitly.

Nothing has shown either to be breaking — they may well compile fine. Adding them now would suppress updates on no evidence, which is a different mistake from the one #467 fixed. If one of them does turn out to break, it gets its own issue and its own entry then.

## Expected effect

The next grouped PR should carry 10 routine updates. Whether it goes green depends on whether `toml` or `tabled` breaks anything — I am not predicting that it will, having already predicted #468 would be green and been wrong.

## Verification

- YAML parses; the `ignore` list is asserted to be exactly `["soroban-sdk", "stellar-xdr", "wasmparser", "cargo_metadata"]`, the group config is unchanged, and there are still exactly two ecosystem entries.
- Configuration only. No code, no workflow, no dependency changed — `Cargo.toml` and `Cargo.lock` untouched.

## Follow-up

Remove the `cargo_metadata` entry when **#469** lands. #469's own acceptance criteria include that reminder, so it does not depend on this description being found later.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cys6yRdswdWxct8J4TQ73F
