### PR TITLE
fix: docs: the lint and formatting configuration is unexplained

### DIFF
--- a/COMMITMSG
+++ b/COMMITMSG
@@ -1,0 +1,9 @@
+fix: address #482
+
+docs: the lint and formatting configuration is unexplained
+
+- update README.md
+
+Fixes #482
+
+Signed-off-by: Vedant Madane <6527493+VedantMadane@users.noreply.github.com>

--- a/README.md
+++ b/README.md
@@ -245,3 +245,7 @@ We welcome contributions! Please see our [CONTRIBUTING.md](CONTRIBUTING.md) for 
 ### 🧑‍💻 Contributors
 
 [![Contributors](https://contrib.rocks/image?repo=Tollcraft/soroban-budget-assert)](https://github.com/Tollcraft/soroban-budget-assert/graphs/contributors)
+
+## Lint and formatting
+
+This repository uses the workspace Clippy and rustfmt settings enforced in CI. Run `cargo fmt` and `cargo clippy --all-targets -- -D warnings` before opening a PR.


### PR DESCRIPTION
## Summary

Addresses #482: docs: the lint and formatting configuration is unexplained

## Changes

- `README.md`

Fixes #482
