### PR TITLE
fix: bring hook installer scripts to behavioral parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- **Pre-commit hook installer parity between `scripts/install-hooks.sh` and `scripts/install-hooks.ps1` (issue #476).** Both installers now validate that `scripts/pre-commit` exists before copying it (a clear error instead of a raw `cp` / `Copy-Item` failure), create the `.git/hooks` directory when it is missing instead of failing, and print the same success message describing what the hook checks and how to recover from a blocked commit. `install-hooks.ps1` also prints an explicit note that the hook is a bash script executed via the bash bundled with Git for Windows, so it runs correctly from PowerShell without a separate Git Bash terminal. `cargo-budget-report/tests/pre_commit_hook.rs` gains coverage for the missing-hooks-directory, double-run, subdirectory, and missing-source states on the shell path, plus a PowerShell-path test that runs when `pwsh` / `powershell` is available on `PATH` and otherwise reports that it was skipped.
+
 ### Added
 
 - **CI/CD integration example documentation (`docs/src/ci_cd_integration.md`).** Adds a reference-style page showing how to integrate `soroban-budget-assert` into a GitHub Actions workflow, covering the complete workflow YAML, step-by-step explanations, customization guidance, best practices, and troubleshooting.

--- a/cargo-budget-report/tests/pre_commit_hook.rs
+++ b/cargo-budget-report/tests/pre_commit_hook.rs
@@ -1,9 +1,21 @@
-//! Integration test for `scripts/pre-commit` + `scripts/install-hooks.sh`.
+//! Integration test for `scripts/pre-commit` + the two hook installers
+//! (`scripts/install-hooks.sh` and `scripts/install-hooks.ps1`).
 //!
-//! Since these are shell scripts, not Rust code, the only meaningful test is
-//! behavioral: install the hook into a real scratch git repository and verify
-//! it actually blocks a commit when `cargo fmt --all -- --check` would fail,
-//! and allows the commit once formatting is fixed.
+//! Since these are shell/PowerShell scripts, not Rust code, the only
+//! meaningful test is behavioral: install the hook into a real scratch git
+//! repository and verify it actually blocks a commit when
+//! `cargo fmt --all -- --check` would fail, and allows the commit once
+//! formatting is fixed. The installer-specific tests additionally cover the
+//! parity states called out in issue #476: a missing `.git/hooks`
+//! directory, running the installer twice, and running it from a
+//! subdirectory of the repo.
+//!
+//! The `install-hooks.ps1` coverage only runs when a `pwsh` or `powershell`
+//! binary is present on `PATH`; this CI and the environment this test suite
+//! was written in have neither, so that coverage has not actually been
+//! exercised here. It is written to run for real wherever PowerShell is
+//! available (e.g. a Windows CI runner), rather than being skipped
+//! unconditionally.
 
 use std::fs;
 use std::path::Path;
@@ -118,6 +130,228 @@ fn pre_commit_hook_blocks_badly_formatted_code() {
     assert!(
         stdout.contains("Formatting check failed") || stderr.contains("Formatting check failed"),
         "expected hook's failure message in output, got stdout={stdout:?} stderr={stderr:?}"
+    );
+}
+
+/// Copies just `scripts/pre-commit` and `scripts/install-hooks.sh` into a
+/// fresh git repo at `dir`, without running the installer, so tests can
+/// exercise the installer themselves under specific starting conditions.
+fn setup_scratch_repo_without_installing(dir: &Path) {
+    let status = Command::new("git")
+        .args(["init"])
+        .current_dir(dir)
+        .status()
+        .expect("git init should run");
+    assert!(status.success(), "git init failed");
+
+    let real_scripts_dir = repo_root().join("scripts");
+    let scratch_scripts_dir = dir.join("scripts");
+    fs::create_dir_all(&scratch_scripts_dir).unwrap();
+    fs::copy(
+        real_scripts_dir.join("pre-commit"),
+        scratch_scripts_dir.join("pre-commit"),
+    )
+    .unwrap();
+    fs::copy(
+        real_scripts_dir.join("install-hooks.sh"),
+        scratch_scripts_dir.join("install-hooks.sh"),
+    )
+    .unwrap();
+}
+
+#[test]
+fn install_hooks_sh_creates_missing_hooks_directory() {
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    let dir = tmp.path();
+    setup_scratch_repo_without_installing(dir);
+
+    // Simulate a `.git/hooks` directory that does not exist.
+    fs::remove_dir_all(dir.join(".git/hooks")).unwrap();
+    assert!(!dir.join(".git/hooks").exists());
+
+    let output = Command::new("bash")
+        .arg("scripts/install-hooks.sh")
+        .current_dir(dir)
+        .output()
+        .expect("install-hooks.sh should run");
+
+    assert!(
+        output.status.success(),
+        "installer should succeed even when .git/hooks is missing; stdout={:?} stderr={:?}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        dir.join(".git/hooks/pre-commit").exists(),
+        "hook was not installed after .git/hooks was recreated"
+    );
+}
+
+#[test]
+fn install_hooks_sh_is_idempotent_when_run_twice() {
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    let dir = tmp.path();
+    setup_scratch_repo_without_installing(dir);
+
+    for _ in 0..2 {
+        let status = Command::new("bash")
+            .arg("scripts/install-hooks.sh")
+            .current_dir(dir)
+            .status()
+            .expect("install-hooks.sh should run");
+        assert!(
+            status.success(),
+            "install-hooks.sh should succeed on every run"
+        );
+    }
+
+    assert!(dir.join(".git/hooks/pre-commit").exists());
+}
+
+#[test]
+fn install_hooks_sh_works_from_a_subdirectory() {
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    let dir = tmp.path();
+    setup_scratch_repo_without_installing(dir);
+
+    let subdir = dir.join("some/nested/dir");
+    fs::create_dir_all(&subdir).unwrap();
+
+    let status = Command::new("bash")
+        .arg(dir.join("scripts/install-hooks.sh"))
+        .current_dir(&subdir)
+        .status()
+        .expect("install-hooks.sh should run");
+    assert!(
+        status.success(),
+        "installer should succeed when invoked from a repo subdirectory"
+    );
+    assert!(dir.join(".git/hooks/pre-commit").exists());
+}
+
+#[test]
+fn install_hooks_sh_fails_clearly_when_source_is_missing() {
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    let dir = tmp.path();
+    setup_scratch_repo_without_installing(dir);
+
+    fs::remove_file(dir.join("scripts/pre-commit")).unwrap();
+
+    let output = Command::new("bash")
+        .arg("scripts/install-hooks.sh")
+        .current_dir(dir)
+        .output()
+        .expect("install-hooks.sh should run");
+
+    assert!(
+        !output.status.success(),
+        "installer should fail (not silently no-op) when the hook source is missing"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Hook source not found"),
+        "expected a clear error about the missing source, got stderr={stderr:?}"
+    );
+    assert!(
+        !dir.join(".git/hooks/pre-commit").exists(),
+        "no hook should have been installed on failure"
+    );
+}
+
+/// Finds a PowerShell binary on `PATH`, preferring `pwsh` (PowerShell Core,
+/// cross-platform) over Windows PowerShell's `powershell`.
+fn find_powershell() -> Option<&'static str> {
+    ["pwsh", "powershell"].into_iter().find(|&candidate| {
+        Command::new(candidate)
+            .arg("-Command")
+            .arg("$PSVersionTable.PSVersion")
+            .output()
+            .is_ok_and(|o| o.status.success())
+    })
+}
+
+/// Covers `scripts/install-hooks.ps1` parity with `install-hooks.sh`:
+/// installs into a real scratch repo and confirms the hook actually blocks
+/// a badly formatted commit. Skips (rather than failing) when no `pwsh` /
+/// `powershell` binary is available, which is the case in this repository's
+/// current CI and was the case in the environment this test was written in.
+#[test]
+fn pre_commit_hook_installed_via_powershell_blocks_badly_formatted_code() {
+    let Some(powershell) = find_powershell() else {
+        eprintln!(
+            "skipping: neither `pwsh` nor `powershell` found on PATH; \
+             install-hooks.ps1 was not exercised by this test run"
+        );
+        return;
+    };
+
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    let dir = tmp.path();
+    fs::create_dir_all(dir.join("src")).unwrap();
+    fs::write(
+        dir.join("Cargo.toml"),
+        "[package]\nname = \"scratch\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+    )
+    .unwrap();
+
+    let status = Command::new("git")
+        .args(["init"])
+        .current_dir(dir)
+        .status()
+        .expect("git init should run");
+    assert!(status.success(), "git init failed");
+    Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(dir)
+        .status()
+        .unwrap();
+    Command::new("git")
+        .args(["config", "user.name", "Test"])
+        .current_dir(dir)
+        .status()
+        .unwrap();
+
+    let real_scripts_dir = repo_root().join("scripts");
+    let scratch_scripts_dir = dir.join("scripts");
+    fs::create_dir_all(&scratch_scripts_dir).unwrap();
+    fs::copy(
+        real_scripts_dir.join("pre-commit"),
+        scratch_scripts_dir.join("pre-commit"),
+    )
+    .unwrap();
+    fs::copy(
+        real_scripts_dir.join("install-hooks.ps1"),
+        scratch_scripts_dir.join("install-hooks.ps1"),
+    )
+    .unwrap();
+
+    let install_status = Command::new(powershell)
+        .args([
+            "-NoProfile",
+            "-NonInteractive",
+            "-File",
+            "scripts/install-hooks.ps1",
+        ])
+        .current_dir(dir)
+        .status()
+        .expect("install-hooks.ps1 should run");
+    assert!(install_status.success(), "install-hooks.ps1 failed");
+    assert!(
+        dir.join(".git/hooks/pre-commit").exists(),
+        "hook was not installed at .git/hooks/pre-commit via install-hooks.ps1"
+    );
+
+    fs::write(
+        dir.join("src/lib.rs"),
+        "pub fn add(a:i32,b:i32)->i32{a+b}\n",
+    )
+    .unwrap();
+    git_add_all(dir);
+    let output = git_commit(dir, "add badly formatted code");
+
+    assert!(
+        !output.status.success(),
+        "commit should have been blocked by the hook installed via install-hooks.ps1"
     );
 }
 

--- a/scripts/install-hooks.ps1
+++ b/scripts/install-hooks.ps1
@@ -18,9 +18,12 @@
 
 .NOTES
     - Requires PowerShell 5.1+ (or PowerShell Core 6+).
+    - Safe to run from any directory inside the repository, and safe to
+      run more than once.
     - The pre-commit hook script itself still uses `#!/usr/bin/env bash`;
       on Windows it is invoked via Git's bundled bash, which is always
-      available in a `git commit` context.
+      available in a `git commit` context as long as Git for Windows
+      (not some bash-less minimal git install) was used to install Git.
     - clippy and tests are intentionally left to CI and the manual
       pre-PR checklist since they take longer to run.
 #>
@@ -34,11 +37,16 @@ if (-not $repoRoot) {
 }
 
 $hookSource = Join-Path $repoRoot "scripts" "pre-commit"
-$hookTarget = Join-Path $repoRoot ".git" "hooks" "pre-commit"
+$hookTargetDir = Join-Path $repoRoot ".git" "hooks"
+$hookTarget = Join-Path $hookTargetDir "pre-commit"
 
 if (-not (Test-Path $hookSource)) {
     Write-Error "Hook source not found at: $hookSource"
     exit 1
+}
+
+if (-not (Test-Path $hookTargetDir)) {
+    New-Item -ItemType Directory -Path $hookTargetDir -Force | Out-Null
 }
 
 Copy-Item -Path $hookSource -Destination $hookTarget -Force
@@ -52,3 +60,10 @@ Write-Host "✅ Installed pre-commit hook -> $hookTarget"
 Write-Host ""
 Write-Host "The hook runs 'cargo fmt --all -- --check' before every commit."
 Write-Host "If it blocks a commit, run 'cargo fmt --all' and commit again."
+Write-Host ""
+Write-Host "Note: this hook is a bash script. It runs via the bash bundled"
+Write-Host "with Git for Windows, so it works even from PowerShell -- no"
+Write-Host "separate Git Bash terminal needs to be open. If your git install"
+Write-Host "does not bundle bash (uncommon), the hook will fail to run and"
+Write-Host "commits will not be checked; reinstall using Git for Windows,"
+Write-Host "or run 'bash scripts/install-hooks.sh' from Git Bash instead."

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -2,14 +2,27 @@
 # Installs repository git hooks (currently: pre-commit formatting check).
 #
 # Run once after cloning: `bash scripts/install-hooks.sh`
+# Safe to run from any directory inside the repository, and safe to run
+# more than once.
 
 set -euo pipefail
 
 repo_root="$(git rev-parse --show-toplevel)"
 hook_source="$repo_root/scripts/pre-commit"
-hook_target="$repo_root/.git/hooks/pre-commit"
+hook_target_dir="$repo_root/.git/hooks"
+hook_target="$hook_target_dir/pre-commit"
+
+if [ ! -f "$hook_source" ]; then
+    echo "❌ Hook source not found at: $hook_source" >&2
+    exit 1
+fi
+
+mkdir -p "$hook_target_dir"
 
 cp "$hook_source" "$hook_target"
 chmod +x "$hook_target"
 
 echo "✅ Installed pre-commit hook -> $hook_target"
+echo ""
+echo "The hook runs 'cargo fmt --all -- --check' before every commit."
+echo "If it blocks a commit, run 'cargo fmt --all' and commit again."


### PR DESCRIPTION
## Summary

`scripts/install-hooks.sh` (Unix) and `scripts/install-hooks.ps1` (Windows)
are supposed to do the same thing but had drifted (15 lines vs. 54).

## Behaviour table (built before making changes, per the issue's own guidance)

| State | `.sh` before | `.ps1` before |
|---|---|---|
| No `.git/hooks` directory | `cp` fails, raw error, `set -e` aborts | `Copy-Item` throws, aborts |
| Existing `pre-commit` hook already installed | Silently overwritten, success message | Same (already matched) |
| Run installer twice | Idempotent | Same (already matched) |
| Run from a subdirectory | Works (`git rev-parse --show-toplevel`) | Same (already matched) |
| Missing `scripts/pre-commit` source | No check, raw `cp` error | Explicit `Test-Path` check, clear error |
| Bash requirement for Windows execution | N/A | Only in buried `.NOTES` help block |
| Success output detail | One line (path only) | Three lines (path, checks, recovery) |

## Fix

Brought both scripts to parity rather than rewriting either: `.sh` gained
the source-existence check and richer success output `.ps1` already had;
both gained `mkdir -p`/`New-Item -Force` for a missing `.git/hooks`
directory; the Git-Bash dependency note is now printed on a normal run,
not just in `Get-Help`. Hook behavior itself (`scripts/pre-commit`)
untouched, as the issue asked.

## Tests

- 5 new tests in `cargo-budget-report/tests/pre_commit_hook.rs`: 4 cover
  the shell path and run for real. The 5th probes for `pwsh`/`powershell`
  on `PATH` at runtime and runs the real PowerShell install+commit flow if
  found — **`pwsh`/`powershell` aren't available in this environment, so
  that test ran in its documented skip path here** rather than actually
  executing the `.ps1` changes. The PowerShell-side changes were verified
  by careful reading against the same logic as the (executed) shell-side
  fix, not by running them. Flagging this plainly rather than claiming
  coverage I don't have.
- `cargo fmt --all -- --check` — clean.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo test -p cargo-budget-report --test pre_commit_hook` — 7/7 passing.
- `cargo test --workspace` — 3 pre-existing failure groups, all confirmed
  identical on `main` before any changes: `amm-pool-contract` needs the
  `wasm32-unknown-unknown` target (unavailable here), `budget-macros --test
  ui` has 6/14 pre-existing trybuild failures, and one `cargo-budget-report`
  unit test fails identically with or without this diff.
- `CHANGELOG.md` updated under `[UNRELEASED]`.

## AI-assisted contribution disclosure

This change was produced with AI assistance (Claude Code) and reviewed by
me before submitting.

## Related issue

Closes #476
