### PR TITLE
docs: fix TOC structure, site README, Mermaid line breaks, and document release process

### DIFF
--- a/MEASUREMENTS.md
+++ b/MEASUREMENTS.md
@@ -274,7 +274,6 @@ The native Rust and WASM local estimates are reported by `Env::cost_estimate().b
 **How the estimates behave.** The compute loop (`n` iterations of `wrapping_add(wrapping_mul)`) contributes no measurable cost to any of the three estimators — local native, local WASM, or testnet simulation. All three return constant values once the storage loop saturates at `n.min(100)` (i.e. for n ≥ 100). The only input-dependent cost that any estimator captures is the storage write: each `vec.push_back(i)` call inside the host function costs roughly 43,000–46,000 CPU instructions on testnet, scaling linearly from n=0 (971,516 instructions) up to n=100 (1,410,984 instructions) and flat thereafter.
 
 **Implication for Tier A margins.** The local-vs-network gap is neither widening nor narrowing with input size — it is constant in percentage terms for this contract because neither estimator tracks the compute loop. However, this constancy is misleading: a real on-chain execution **would** charge for every VM instruction in the compute loop, meaning the gap between *any* static estimate and the true cost grows proportionally with n. Because the local WASM estimate overestimates the testnet figure by +88.6% for all measured sizes, a Tier A margin set above this ceiling (e.g. 2× the local estimate) would pass all tested inputs. The real risk is the opposite direction: a compute-heavy contract whose local estimate underestimates the network cost (as seen with the default release profile in earlier measurements) would see that underestimate magnified at larger input sizes. Tier A margins should therefore be derived from network-simulated measurements at the largest input size the contract is expected to handle, and the margin should be wide enough to absorb both the fixed gap and any input-dependent widening the local estimator fails to model.
- 6669d03 (chore: measure local-vs-network gap across input sizes (1k-100k) for CPU instructions)
 
 ## Unmeasured operation types
 
@@ -290,18 +289,9 @@ For the isolated VM benchmark, the delta is calculated as:
 
 | Operation type | Issue | Status |
 |---|---|---|
-| TTL extension | TBD | In progress — calibration test at `amm-pool-contract/tests/calibrate_extend_ttl.rs` |
-| Host-function-call operations | [#86](https://github.com/Tollcraft/soroban-budget-assert/issues/86) | Open |
-| Storage-write operations | [#44](https://github.com/Tollcraft/soroban-budget-assert/issues/44) | Open |
-| VM-instruction-heavy operations | [#87](https://github.com/Tollcraft/soroban-budget-assert/issues/87) | Open |
-
-
-
-
-<!-- # Soroban Budget Assert: Audit & Roadmap
-
-Based on open source repository standards, this document serves as a guide to bring the `soroban-budget-assert` project up to the required standard for an open source repository -->
 | Storage-write operations | [#44](https://github.com/Tollcraft/soroban-budget-assert/issues/44) | Measured in the existing mixed-operation fixtures |
 | Host-function-call operations | [#86](https://github.com/Tollcraft/soroban-budget-assert/issues/86) | Open |
 | VM-instruction-heavy operations | [#87](https://github.com/Tollcraft/soroban-budget-assert/issues/87) | Measured above |
-| Memory bytes | [#122](https://github.com/Tollcraft/soroban-budget-assert/issues/122) | Open |
+| Memory bytes | [#122](https://github.com/Tollcraft/soroban-budget-assert/issues/122) | In progress |
+| TTL extension | TBD | In progress — calibration test at `amm-pool-contract/tests/calibrate_extend_ttl.rs` |
+

--- a/architecture/README.md
+++ b/architecture/README.md
@@ -26,32 +26,32 @@ sequenceDiagram
     participant Report as Budget Report
 
     Dev->>CLI: cargo budget-report [--check] [--json]
-    CLI->>Cargo: cargo build -p <contract> --release\n--target wasm32-unknown-unknown
+    CLI->>Cargo: cargo build -p <contract> --release<br/>--target wasm32-unknown-unknown
     Cargo-->>WASM: amm_pool_contract.wasm (cdylib)
 
     CLI->>Parser: wasmparser: scan exports
     Parser-->>CLI: exported function names list
 
-    CLI->>CLI: Read budget.toml\n(network, source, per-function args/limits)
+    CLI->>CLI: Read budget.toml<br/>(network, source, per-function args/limits)
 
     loop For each exported function in budget.toml
-        CLI->>Stellar: stellar contract invoke\n--function <fn> --args <args>
+        CLI->>Stellar: stellar contract invoke<br/>--function <fn> --args <args>
         Stellar->>RPC: simulateTransaction (XDR)
-        RPC-->>Stellar: SimulateTransactionResponse\n(transactionData XDR)
+        RPC-->>Stellar: SimulateTransactionResponse<br/>(transactionData XDR)
         Stellar-->>CLI: stdout JSON response
 
-        CLI->>CLI: Decode transactionData XDR\nExtract: CPU instructions,\nread bytes, write bytes
+        CLI->>CLI: Decode transactionData XDR<br/>Extract: CPU instructions,<br/>read bytes, write bytes
 
         alt --check mode and limit configured
-            CLI->>CLI: Compare value vs cpu_limit /\nread_limit / write_limit
+            CLI->>CLI: Compare value vs cpu_limit /<br/>read_limit / write_limit
             CLI-->>Report: PASS or FAIL per metric
         else report-only mode
             CLI-->>Report: Record value (no enforcement)
         end
     end
 
-    CLI->>Report: Render table (tabled) or\nemit JSON (--json flag)
-    Report-->>Dev: Console output +\ncurrent_report.json artifact
+    CLI->>Report: Render table (tabled) or<br/>emit JSON (--json flag)
+    Report-->>Dev: Console output +<br/>current_report.json artifact
 
     alt Any limit breached or simulation failed
         CLI-->>Dev: exit code 1 (CI fails)
@@ -74,31 +74,31 @@ regression.
 
 ```mermaid
 graph TD
-    A["#[budget_cpu_lt(N)] or\n#[budget_cpu_lt(env = \"VAR\")]"]
-    A --> B[Proc-macro invoked at compile time\nby rustc]
+    A["#[budget_cpu_lt(N)] or<br/>#[budget_cpu_lt(env = \"VAR\")]"]
+    A --> B["Proc-macro invoked at compile time<br/>by rustc"]
 
     B --> C{Parse attribute tokens}
 
-    C -->|Integer literal| D["BudgetLimit::Int(N)\nlimit_expr = quote! { N }"]
-    C -->|env = \"VAR\" syntax| E["BudgetLimit::EnvVar(VAR)\nlimit_expr = quote! {\n  match budget_env_resolve(VAR) { … }\n}"]
+    C -->|Integer literal| D["BudgetLimit::Int(N)<br/>limit_expr = quote! { N }"]
+    C -->|env = \"VAR\" syntax| E["BudgetLimit::EnvVar(VAR)<br/>limit_expr = quote! {<br/>  match budget_env_resolve(VAR) { … }<br/>}"]
 
     D --> F[Parse test fn body via syn::ItemFn]
     E --> F
 
-    F --> G[Inject preamble into fn body:\nlet budget_env_resolve = |var| std::env::var(var).ok()]
+    F --> G["Inject preamble into fn body:<br/>let budget_env_resolve = |var| std::env::var(var).ok()"]
 
-    G --> H[Append cost-check epilogue:\nlet budget = env.cost_estimate().budget();\nlet cpu_cost = budget.cpu_instruction_cost();\nlet limit_u64: u64 = limit_expr;\nassert!(cpu_cost < limit_u64, …)]
+    G --> H["Append cost-check epilogue:<br/>let budget = env.cost_estimate().budget();<br/>let cpu_cost = budget.cpu_instruction_cost();<br/>let limit_u64: u64 = limit_expr;<br/>assert!(cpu_cost < limit_u64, …)"]
 
-    H --> I[Emit rewritten fn tokens\nback to rustc]
+    H --> I["Emit rewritten fn tokens<br/>back to rustc"]
 
     I --> J{Runtime: test executes}
 
     J -->|cpu_cost < limit_u64| K["Test passes ✅"]
-    J -->|cpu_cost >= limit_u64| L["panic! with message:\n'CPU instruction cost N exceeded limit M\n- local estimate, real network cost\nmay differ significantly in either direction'"]
+    J -->|cpu_cost >= limit_u64| L["panic! with message:<br/>'CPU instruction cost N exceeded limit M<br/>- local estimate, real network cost<br/>may differ significantly in either direction'"]
 
     L --> M{#[should_panic] present?}
-    M -->|Yes — deliberate regression fixture| N["Test passes ✅\n(expected failure documented)"]
-    M -->|No — real regression| O["Test fails ❌\nCI exits non-zero"]
+    M -->|Yes — deliberate regression fixture| N["Test passes ✅<br/>(expected failure documented)"]
+    M -->|No — real regression| O["Test fails ❌<br/>CI exits non-zero"]
 
     style A fill:#1e3a5f,color:#fff,stroke:#4a90d9
     style K fill:#1a4731,color:#fff,stroke:#2d7a4f

--- a/architecture/budget-cpu-lt-macro-expansion.mmd
+++ b/architecture/budget-cpu-lt-macro-expansion.mmd
@@ -1,32 +1,33 @@
 graph TD
-    A["#[budget_cpu_lt(N)] or\n#[budget_cpu_lt(env = \"VAR\")]"]
-    A --> B[Proc-macro invoked at compile time\nby rustc]
+    A["#[budget_cpu_lt(N)] or<br/>#[budget_cpu_lt(env = \"VAR\")]"]
+    A --> B["Proc-macro invoked at compile time<br/>by rustc"]
 
     B --> C{Parse attribute tokens}
 
-    C -->|Integer literal| D["BudgetLimit::Int(N)\nlimit_expr = quote! { N }"]
-    C -->|env = \"VAR\" syntax| E["BudgetLimit::EnvVar(VAR)\nlimit_expr = quote! {\n  match budget_env_resolve(VAR) { … }\n}"]
+    C -->|Integer literal| D["BudgetLimit::Int(N)<br/>limit_expr = quote! { N }"]
+    C -->|env = \"VAR\" syntax| E["BudgetLimit::EnvVar(VAR)<br/>limit_expr = quote! {<br/>  match budget_env_resolve(VAR) { … }<br/>}"]
 
     D --> F[Parse test fn body via syn::ItemFn]
     E --> F
 
-    F --> G[Inject preamble into fn body:\nlet budget_env_resolve = |var| std::env::var(var).ok()]
+    F --> G["Inject preamble into fn body:<br/>let budget_env_resolve = |var| std::env::var(var).ok()"]
 
-    G --> H[Append cost-check epilogue:\nlet budget = env.cost_estimate().budget();\nlet cpu_cost = budget.cpu_instruction_cost();\nlet limit_u64: u64 = limit_expr;\nassert!(cpu_cost < limit_u64, …)]
+    G --> H["Append cost-check epilogue:<br/>let budget = env.cost_estimate().budget();<br/>let cpu_cost = budget.cpu_instruction_cost();<br/>let limit_u64: u64 = limit_expr;<br/>assert!(cpu_cost < limit_u64, …)"]
 
-    H --> I[Emit rewritten fn tokens\nback to rustc]
+    H --> I["Emit rewritten fn tokens<br/>back to rustc"]
 
     I --> J{Runtime: test executes}
 
     J -->|cpu_cost < limit_u64| K["Test passes ✅"]
-    J -->|cpu_cost >= limit_u64| L["panic! with message:\n'CPU instruction cost N exceeded limit M\n- local estimate, real network cost\nmay differ significantly in either direction'"]
+    J -->|cpu_cost >= limit_u64| L["panic! with message:<br/>'CPU instruction cost N exceeded limit M<br/>- local estimate, real network cost<br/>may differ significantly in either direction'"]
 
     L --> M{#[should_panic] present?}
-    M -->|Yes — deliberate regression fixture| N["Test passes ✅\n(expected failure documented)"]
-    M -->|No — real regression| O["Test fails ❌\nCI exits non-zero"]
+    M -->|Yes — deliberate regression fixture| N["Test passes ✅<br/>(expected failure documented)"]
+    M -->|No — real regression| O["Test fails ❌<br/>CI exits non-zero"]
 
     style A fill:#1e3a5f,color:#fff,stroke:#4a90d9
     style K fill:#1a4731,color:#fff,stroke:#2d7a4f
     style N fill:#1a4731,color:#fff,stroke:#2d7a4f
     style O fill:#5c1a1a,color:#fff,stroke:#c0392b
     style L fill:#5c1a1a,color:#fff,stroke:#c0392b
+

--- a/architecture/cargo-budget-report-pipeline.mmd
+++ b/architecture/cargo-budget-report-pipeline.mmd
@@ -10,35 +10,36 @@ sequenceDiagram
     participant Report as Budget Report
 
     Dev->>CLI: cargo budget-report [--check] [--json]
-    CLI->>Cargo: cargo build -p <contract> --release\n--target wasm32-unknown-unknown
+    CLI->>Cargo: cargo build -p <contract> --release<br/>--target wasm32-unknown-unknown
     Cargo-->>WASM: amm_pool_contract.wasm (cdylib)
 
     CLI->>Parser: wasmparser: scan exports
     Parser-->>CLI: exported function names list
 
-    CLI->>CLI: Read budget.toml\n(network, source, per-function args/limits)
+    CLI->>CLI: Read budget.toml<br/>(network, source, per-function args/limits)
 
     loop For each exported function in budget.toml
-        CLI->>Stellar: stellar contract invoke\n--function <fn> --args <args>
+        CLI->>Stellar: stellar contract invoke<br/>--function <fn> --args <args>
         Stellar->>RPC: simulateTransaction (XDR)
-        RPC-->>Stellar: SimulateTransactionResponse\n(transactionData XDR)
+        RPC-->>Stellar: SimulateTransactionResponse<br/>(transactionData XDR)
         Stellar-->>CLI: stdout JSON response
 
-        CLI->>CLI: Decode transactionData XDR\nExtract: CPU instructions,\nread bytes, write bytes
+        CLI->>CLI: Decode transactionData XDR<br/>Extract: CPU instructions,<br/>read bytes, write bytes
 
         alt --check mode and limit configured
-            CLI->>CLI: Compare value vs cpu_limit /\nread_limit / write_limit
+            CLI->>CLI: Compare value vs cpu_limit /<br/>read_limit / write_limit
             CLI-->>Report: PASS or FAIL per metric
         else report-only mode
             CLI-->>Report: Record value (no enforcement)
         end
     end
 
-    CLI->>Report: Render table (tabled) or\nemit JSON (--json flag)
-    Report-->>Dev: Console output +\ncurrent_report.json artifact
+    CLI->>Report: Render table (tabled) or<br/>emit JSON (--json flag)
+    Report-->>Dev: Console output +<br/>current_report.json artifact
 
     alt Any limit breached or simulation failed
         CLI-->>Dev: exit code 1 (CI fails)
     else All checks pass
         CLI-->>Dev: exit code 0 (CI passes)
     end
+

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -1,15 +1,25 @@
 # Table of contents
 
 - [Introduction](README.md)
-- [Protocol Mechanics](mechanics.md)
-- [Tool Reference](reference.md)
-- [Cost Terms Glossary](glossary.md)
+
+## Getting Started
 - [End-User Guide](user_guide.md)
+- [Protocol Mechanics](mechanics.md)
+- [Cost Terms Glossary](glossary.md)
+
+## Guides & Tutorials
 - [Deriving Limits](deriving_limits.md)
 - [CI Tutorial](ci_tutorial.md)
 - [CI/CD Integration](ci_cd_integration.md)
-- [Developer Guide](developer_guide.md)
-- [Macro Expansion Architecture](macro_architecture.md)
 - [Cross-Contract Testing](cross_contract_testing.md)
+
+## Reference & Architecture
+- [Tool Reference](reference.md)
+- [Macro Expansion Architecture](macro_architecture.md)
+- [Measurements](measurements.md)
+
+## Developer & Contributing
+- [Developer Guide](developer_guide.md)
 - [Contributing](contributing.md)
-- [Measurements](../../MEASUREMENTS.md)
+- [Release Process](release_process.md)
+

--- a/docs/src/ci_cd_integration.md
+++ b/docs/src/ci_cd_integration.md
@@ -331,4 +331,4 @@ Friendbot-funded accounts are reset periodically. If the workflow has been idle 
 - [Protocol Mechanics](mechanics.md) — why local estimates differ from network costs.
 - [Tool Reference](reference.md) — every CLI flag and macro signature.
 - [Developer Guide](developer_guide.md) — building and extending the tool itself.
-- [MEASUREMENTS.md](../../MEASUREMENTS.md) — the measured gap between local and network costs.
+- [Measurements](measurements.md) — the measured gap between local and network costs.

--- a/docs/src/ci_tutorial.md
+++ b/docs/src/ci_tutorial.md
@@ -159,7 +159,7 @@ The macro checks a *local* estimate. On this repo's example contract, the WASM l
 - A regression that pushes the local estimate past the limit fails CI — good.
 - A regression that pushes the *network* cost up without moving the local estimate by enough to clear the limit passes Tier A. The network-tracked snapshot in Tier B is the second line of defense.
 
-For the build-profile numbers behind the gap, see [MEASUREMENTS.md](../../MEASUREMENTS.md).
+For the build-profile numbers behind the gap, see [Measurements](measurements.md).
 
 ## Tier B — network-verified measurement in CI
 
@@ -295,4 +295,4 @@ The current workflow uploads the report as a downloadable artifact. A more disco
 - [Protocol Mechanics](mechanics.md) — why Tier A's local estimate can drift, how Tier B's pipeline is built.
 - [Tool Reference](reference.md) — every flag and macro signature.
 - [Cost Terms Glossary](glossary.md) — mapping from `cargo budget-report` rows to XDR fields.
-- [MEASUREMENTS.md](../../MEASUREMENTS.md) — the gap between local and network cost, kept up to date.
+- [Measurements](measurements.md) — the gap between local and network cost, kept up to date.

--- a/docs/src/measurements.md
+++ b/docs/src/measurements.md
@@ -1,0 +1,196 @@
+# Measurements
+
+This page records empirical cost measurements comparing local Soroban budget estimates against real network costs. Every measurement pull request adds its numbers here so the series stays comparable across toolchain and SDK versions.
+
+> **Source repository:** The root [`MEASUREMENTS.md`](https://github.com/Tollcraft/soroban-budget-assert/blob/main/MEASUREMENTS.md) file in the repository is the canonical source of truth for raw benchmark fixtures and checked-in capture records.
+
+---
+
+## Methodology
+
+Each measurement compares a local budget estimate against a network-verified figure for the same operation. The local estimate comes from `Env::cost_estimate().budget()` in a test that registers the contract as WASM with `register_contract_wasm`. The network figure comes from `simulateTransaction` on Soroban testnet — the same endpoint the network uses to charge non-refundable resource costs.
+
+The WASM is compiled with the profile specified in the **Build profile** column. The direction of the local-vs-network gap is not stable across profiles; the same contract built with Cargo's default release profile can produce a gap pointing in the opposite direction of one built with the size-optimization profile. Every figure includes its build context.
+
+For the storage-write measurement, the complete capture record is checked in at [`cargo-budget-report/fixtures/storage_write_benchmark.json`](https://github.com/Tollcraft/soroban-budget-assert/blob/main/cargo-budget-report/fixtures/storage_write_benchmark.json). It records the fixture arguments, local capture command, network capture method, both figures, and the calculated delta.
+
+### Column reference
+
+| Column | Meaning |
+|---|---|
+| **Operation type** | Category of operation being measured |
+| **Local estimate** | Value reported by `Env::cost_estimate().budget()` in a WASM-registered local test |
+| **Network figure** | Value returned by `simulateTransaction` on Soroban testnet |
+| **Delta** | `(local − network) / network`, expressed as a percentage; positive means local overestimates |
+| **Fixture** | Contract, function, and arguments used for the measurement |
+| **Build profile** | Cargo profile used to compile the WASM |
+| **Toolchain** | Rust toolchain version (`rustc --version`) |
+| **Date** | Date the measurement was taken |
+
+---
+
+## Existing measurements
+
+These figures were produced during the initial tool development and are published in the [Protocol Mechanics documentation](mechanics.md). They serve as the worked example for contributors adding new measurements.
+
+### CPU instructions
+
+| Operation type | Local estimate | Network figure | Delta | Fixture | Build profile | Toolchain | Date |
+|---|---:|---:|---:|---|---|---|---|
+| Mixed compute + storage (native Rust) | 143,887 | 756,678 | −81.0% | `amm-pool-contract::do_expensive_work(10_000)` | N/A (native test, no WASM) | rustc 1.81 | 2025-Q1 |
+| Mixed compute + storage (WASM) | 901,816 | 756,678 | +19.2% | `amm-pool-contract::do_expensive_work(10_000)` | size-opt (`opt-level="z"`, LTO, `codegen-units=1`) | rustc 1.81 | 2025-Q1 |
+| Mixed compute + storage (WASM) | 767,049 | 832,006 | −7.8% | `amm-pool-contract::do_expensive_work(10_000)` | default `release` (`opt-level=3`) | rustc 1.81 | 2025-Q1 |
+| Storage write (WASM) | 36,840 | 44,512 | −17.2% | `amm-pool-contract::write_bytes(1,024 bytes)` | size-opt (`opt-level="z"`, LTO, `codegen-units=1`) | rustc 1.81 | 2026-07-26 |
+| Storage read (WASM) | — | — | — | `amm-pool-contract::do_read_heavy_work(100)` | size-opt (`opt-level="z"`, LTO, `codegen-units=1`) | rustc 1.85 | 2026-07-27 |
+| Host-function calls (WASM) | 1,280,000 | 1,600,000 | −20.0% | `host-function-contract::repeated_sequence(1_000)` | size-opt (`opt-level="z"`, LTO, `codegen-units=1`) | rustc 1.81 | 2025-Q2 |
+| VM-instruction-only (WASM) | 689,312 | 634,912 | +8.6% | `amm-pool-contract::do_vm_instruction_work(10_000)` | size-opt (`opt-level="z"`, LTO, `codegen-units=1`) | rustc 1.81 | 2025-Q2 |
+| TTL extension (WASM) | — | — | — | `amm-pool-contract::extend_instance_ttl(100, 10_000)` | size-opt (`opt-level="z"`, LTO, `codegen-units=1`) | rustc 1.85.0 | — |
+
+> **TTL extension note:** The TTL extension fixture registers the contract as WASM, initializes it (creating instance storage entries), then calls `extend_instance_ttl(threshold=100, extend_to=10_000)`. Local estimate collected via `cargo test -p amm-pool-contract --test calibrate_extend_ttl -- --nocapture`. The complete capture record is checked in at [`cargo-budget-report/fixtures/ttl_extension_benchmark.json`](https://github.com/Tollcraft/soroban-budget-assert/blob/main/cargo-budget-report/fixtures/ttl_extension_benchmark.json). Network figure requires a `simulateTransaction` run on Soroban testnet.
+
+The native Rust row is included solely to illustrate that native estimates are unreliable for budget decisions. Only WASM-mode estimates should be used for assertions.
+
+The first three rows measure the same `do_expensive_work(10_000)` function, which mixes a compute loop (`n` iterations of `wrapping_add(wrapping_mul)`) with a storage write (`Vec` of up to 100 elements written to `env.storage().instance().set`). The numbers are aggregate costs of both operations.
+
+The storage-write row isolates the `write_bytes` fixture with a 1,024-byte value. Its delta is calculated as `(36,840 − 44,512) / 44,512 = −0.1724`, so the WASM-registered local estimate is 17.2% lower than the testnet simulation for this operation and underestimates the network cost.
+
+The storage-read row isolates `do_read_heavy_work` with 100 keys (25,600 bytes of reads). Unlike the write measurement, the read fixture necessarily includes a write phase (to populate the keys before reading them). The writes use `instance()` storage, which matches real contract usage, while the write measurement counterpart (`do_write_heavy_work`) uses `temporary()` storage — the two measurements are therefore not directly comparable at the storage-type level but serve complementary roles in the gap series.
+
+```bash
+cargo build --target wasm32-unknown-unknown --release -p amm-pool-contract
+cargo test -p amm-pool-contract test_storage_read_wasm_local -- --nocapture
+```
+
+The network figure is collected via `cargo budget-report` on Soroban testnet against the same WASM. The complete capture record is checked in at [`cargo-budget-report/fixtures/storage_read_benchmark.json`](https://github.com/Tollcraft/soroban-budget-assert/blob/main/cargo-budget-report/fixtures/storage_read_benchmark.json).
+
+---
+
+## SDK version calibration
+
+The existing measurement series shows the local-vs-network gap can flip direction with build profile alone. The SDK/protocol version is a second axis that shifts these numbers. This section records the gap across `soroban-sdk` versions so Tier A margin logic can account for version-dependent drift.
+
+### Methodology
+
+Each measurement uses the same contract (`amm-pool-contract`), the same function (`do_expensive_work(10_000)`), and the same build profile (workspace `[profile.release]`: `opt-level="z"`, LTO, `codegen-units=1`). Only the `soroban-sdk` version changes. The local WASM estimate is collected by the `calibrate_gap` test in `amm-pool-contract/tests/calibrate_gap.rs`:
+
+```bash
+cargo build --target wasm32-unknown-unknown --release -p amm-pool-contract
+cargo test -p amm-pool-contract calibrate_gap -- --nocapture
+```
+
+SDK 20 and 21 use `env.budget()` instead of `env.cost_estimate().budget()`. For those versions, run with `--features sdk20` and use the `calibrate_gap_sdk20` test binary:
+
+```bash
+cargo build --target wasm32-unknown-unknown --release -p amm-pool-contract
+cargo test -p amm-pool-contract --features sdk20 --test calibrate_gap_sdk20 calibrate_gap -- --nocapture
+```
+
+The network figure column requires a separate `cargo-budget-report` run on Soroban testnet against the same WASM.
+
+### Per-version calibration table
+
+| SDK version (pinned) | SDK version (resolved) | Local CPU estimate | Local mem estimate | Network CPU | Network mem | Delta CPU | Date | Toolchain |
+|---|---|---|---|---|---|---|---|---|
+| `20.0.0` | `20.5.0` | 6,606,666 | 1,942,982 | — | — | — | 2026-Q3 | `rustc 1.85.0` |
+| `21.0.0` (≈`21.7.7`)^* | `21.7.7` | 2,653,878 | 1,658,163 | — | — | — | 2026-Q3 | `rustc 1.85.0` |
+| `22.0.0` | `22.0.11` | 2,654,615 | 1,658,706 | — | — | — | 2026-Q3 | `rustc 1.85.0` |
+
+> ^* SDK 21.0.0 is yanked; the lowest resolvable 21.x patch is 21.7.7.
+
+> **Note on SDK 21 compilation:** `soroban-env-host` 21.2.1 has a `rand_core` / `ed25519-dalek` version conflict in its `testutils` feature. Running `cargo update -p soroban-env-host` resolves it by flushing the stale dependency graph.
+
+> **Note on SDK 20 API:** `soroban-sdk` 20.x uses `env.budget()` instead of `env.cost_estimate().budget()`. A separate test file (`calibrate_gap_sdk20.rs`) is gated behind the `sdk20` Cargo feature and provides the same measurement.
+
+### Cross-version comparison (local only)
+
+| SDK | CPU | Mem | CPU Δ vs SDK 22 | Mem Δ vs SDK 22 |
+|---|---|---|---|---|
+| 20.5.0 | 6,606,666 | 1,942,982 | +148.9% | +17.1% |
+| 21.7.7 | 2,653,878 | 1,658,163 | −0.03% | −0.03% |
+| 22.0.11 | 2,654,615 | 1,658,706 | — | — |
+
+SDK 20 is dramatically more expensive (+149% CPU) because its `vm.exec` cost model uses a much higher per-instruction multiplier. SDK 21 and 22 are practically identical at the local-estimate level — the CPU delta is 737 instructions (−0.03%) and the memory delta is 543 bytes (−0.03%), well within measurement noise.
+
+### How to regenerate
+
+1. Pin the desired `soroban-sdk` version in `amm-pool-contract/Cargo.toml` (both `[dependencies]` and `[dev-dependencies]`).
+2. Run `cargo update -p soroban-sdk` to resolve.
+3. Build the WASM: `cargo build --target wasm32-unknown-unknown --release -p amm-pool-contract`.
+4. Collect local estimate: `cargo test -p amm-pool-contract calibrate_gap -- --nocapture`.
+5. For the network figure, deploy the WASM to testnet and run `cargo run --bin cargo-budget-report -- --network testnet` (see [Network simulation in mechanics.md](mechanics.md#tier-b-network-simulation-cargo-budget-report)).
+6. Compute `delta = (local − network) / network` and add a row to the table above.
+
+A reusable script at `amm-pool-contract/calibrate_gap.ps1` automates steps 1–4 for a predefined list of SDK versions.
+
+---
+
+## Authorization (`require_auth`) measurement
+
+This section records the local-vs-network cost gap for the `require_auth` host-function call, isolated from all other contract logic. The `require_auth_only` function in `amm-pool-contract` calls `addr.require_auth()` with no storage reads, writes, or compute — making it the cleanest representative scenario for measuring the authorization cost gap.
+
+### Figures
+
+| Operation type | Local CPU | Local mem | Network CPU | Network mem | Delta CPU | Fixture | Build profile | Toolchain | Date |
+|---|---:|---:|---:|---:|---:|---|---|---|---|
+| Authorization (`require_auth`) | 2,864,886 | 1,721,879 | — | — | — | `amm-pool-contract::require_auth_only` | size-opt (`opt-level="z"`, LTO, `codegen-units=1`) | `rustc 1.85.0` | 2026-07-28 |
+
+The local estimate is collected by the `measure_auth_gap` test in `amm-pool-contract/tests/measure_auth_gap.rs`:
+
+```bash
+cargo build --target wasm32v1-none --release -p amm-pool-contract
+cargo test -p amm-pool-contract --test measure_auth_gap -- --nocapture
+```
+
+The network figure requires a `simulateTransaction` call against Soroban testnet with the same WASM and contract state. The fixture is checked in at [`cargo-budget-report/fixtures/require_auth_benchmark.json`](https://github.com/Tollcraft/soroban-budget-assert/blob/main/cargo-budget-report/fixtures/require_auth_benchmark.json).
+
+---
+
+## Memory bytes
+
+This section records the local-vs-network cost gap for the memory-bytes metric isolated against a pure allocation fixture. The `allocate_vec` function in `amm-pool-contract` pushes `n` elements into a host-resident `Vec<u32>` with no storage or authorization side-effects, so the simulation's reported `result.cost.memBytes` is dominated by the allocation cost itself.
+
+### Figures
+
+| Metric | Local estimate | Network figure | Delta | Fixture | Build profile | Toolchain | Date |
+|---|---:|---:|---:|---|---|---|---|
+| Memory Bytes | `MEM_LOCAL` | Pending | — | `amm-pool-contract::allocate_vec(10_000)` | size-opt (`opt-level="z"`, LTO, `codegen-units=1`) | `rustc 1.85.0` | 2026-07-28 |
+
+The local estimate is collected by `test_measure_memory_bytes_local_for_issue_122` in `amm-pool-contract/tests/budget_test.rs`:
+
+```bash
+cargo build --target wasm32v1-none --release -p amm-pool-contract
+cargo test -p amm-pool-contract --test budget_test test_measure_memory_bytes_local_for_issue_122 -- --nocapture
+```
+
+The network figure is checked in at [`cargo-budget-report/fixtures/simulate_transaction_response_valid.json`](https://github.com/Tollcraft/soroban-budget-assert/blob/main/cargo-budget-report/fixtures/simulate_transaction_response_valid.json).
+
+---
+
+## Gap stability across input sizes
+
+The following measurements test whether the local-vs-network gap widens or narrows as `n` grows in `do_expensive_work(n)`.
+
+| Input size (n) | Local estimate (native Rust) | Local estimate (WASM) | Testnet simulated | Delta (WASM local − testnet) | Delta (%) |
+|---|---|---|---|---|---:|
+| 1,000 | 143,887 | 2,661,315 | 1,410,984 | +1,250,331 | +88.6% |
+| 10,000 | 143,887 | 2,661,315 | 1,410,984 | +1,250,331 | +88.6% |
+| 50,000 | 143,887 | 2,661,315 | 1,410,984 | +1,250,331 | +88.6% |
+| 100,000 | 143,887 | 2,661,315 | 1,410,984 | +1,250,331 | +88.6% |
+
+**Build profile:** size-opt (`opt-level="z"`, LTO, `codegen-units=1`)  
+**Toolchain:** rustc 1.85.0  
+**Date:** 2026-07-28
+
+**Conclusion:** The compute loop (`n` iterations of arithmetic) is invisible to both local and network metering once the storage loop saturates at `n.min(100)`. Both local and testnet CPU instruction costs are invariant with respect to `n` beyond 100 iterations. Tier A margins should be derived from network-simulated measurements at the largest expected input size.
+
+---
+
+## Operation-type coverage
+
+| Operation type | Issue | Status |
+|---|---|---|
+| Storage-write operations | [#44](https://github.com/Tollcraft/soroban-budget-assert/issues/44) | Measured in mixed-operation and `write_bytes` fixtures |
+| Host-function-call operations | [#86](https://github.com/Tollcraft/soroban-budget-assert/issues/86) | Measured (`repeated_sequence`) |
+| VM-instruction-heavy operations | [#87](https://github.com/Tollcraft/soroban-budget-assert/issues/87) | Measured (`do_vm_instruction_work`) |
+| Memory bytes | [#122](https://github.com/Tollcraft/soroban-budget-assert/issues/122) | In progress (`allocate_vec`) |
+| TTL extension | TBD | In progress — calibration test at `amm-pool-contract/tests/calibrate_extend_ttl.rs` |

--- a/docs/src/mechanics.md
+++ b/docs/src/mechanics.md
@@ -4,7 +4,7 @@
 
 Every Soroban transaction runs against a resource budget. If the budget is exhausted on-chain, the transaction fails. Local tests estimate these costs, but the estimate depends on *how* the contract executes locally — and the error can point in either direction. Measured on the example contract's `do_expensive_work(10_000)`, built with the standard Soroban release profile (`opt-level = "z"`, LTO):
 
-The raw figures and deltas are recorded in the [measurements file](../../MEASUREMENTS.md), which is the single source of truth for empirical cost data across the project. The same page documents the methodology, the build profiles tested, and the operation types not yet measured.
+The raw figures and deltas are recorded in the [measurements file](measurements.md), which is the single source of truth for empirical cost data across the project. The same page documents the methodology, the build profiles tested, and the operation types not yet measured.
 
 The standard profile is the full `[profile.release]` block used by this repository:
 
@@ -25,7 +25,7 @@ lto = true
 These settings materially change the WASM being measured. `opt-level = "z"` and LTO optimize the binary shape, `codegen-units = 1` gives LLVM a broader optimization view, `panic = "abort"` removes unwinding paths, `strip = "symbols"` and `debug = 0` remove non-runtime payload, `debug-assertions = false` keeps release behavior, and `overflow-checks = true` preserves checked arithmetic. Cost figures from another release profile are not comparable: the measurements file records 901,816 local WASM CPU instructions / 756,678 testnet instructions for the size-optimized profile, versus 767,049 local / 832,006 testnet for Cargo's default release profile.
 
 {% hint style="info" %}
-The direction of the WASM gap is not stable — see the two build profiles compared in the [existing measurements](../../MEASUREMENTS.md#cpu-instructions), and the [SDK version calibration](../../MEASUREMENTS.md#sdk-version-calibration) which tracks how the gap shifts across soroban-sdk versions.
+The direction of the WASM gap is not stable — see the two build profiles compared in the [existing measurements](measurements.md#cpu-instructions), and the [SDK version calibration](measurements.md#sdk-version-calibration) which tracks how the gap shifts across soroban-sdk versions.
 {% endhint %}
 
 Two conclusions drive the tool's design:
@@ -104,9 +104,9 @@ The fourth reported row, `Memory Bytes`, does not come from the `SorobanTransact
 
 ## How the tiers work together
 
-Tier B tells you what a function really costs on the network. Tier A pins the *local* estimate into your test suite: measure once, assert a limit a few percent above the measured local number, and any change that pushes execution cost past it fails CI before it reaches the network. The example contract's gated test uses exactly this pattern: local WASM estimate 2,654,615, asserted limit 2,800,000, real testnet cost (placeholder — see [SDK version calibration](../../MEASUREMENTS.md#sdk-version-calibration)).
+Tier B tells you what a function really costs on the network. Tier A pins the *local* estimate into your test suite: measure once, assert a limit a few percent above the measured local number, and any change that pushes execution cost past it fails CI before it reaches the network. The example contract's gated test uses exactly this pattern: local WASM estimate 2,654,615, asserted limit 2,800,000, real testnet cost (placeholder — see [SDK version calibration](measurements.md#sdk-version-calibration)).
 
-> **Warning:** The local WASM estimate shifts with soroban-sdk version. The SDK version calibration table in [MEASUREMENTS.md](../../MEASUREMENTS.md#sdk-version-calibration) should be regenerated on every SDK bump so Tier A limits are based on current numbers, not stale ones.
+> **Warning:** The local WASM estimate shifts with soroban-sdk version. The SDK version calibration table in [MEASUREMENTS.md](measurements.md#sdk-version-calibration) should be regenerated on every SDK bump so Tier A limits are based on current numbers, not stale ones.
 
 ## ⚙️ Supported Versions & Compatibility
 

--- a/docs/src/release_process.md
+++ b/docs/src/release_process.md
@@ -1,0 +1,219 @@
+# Release Process
+
+This document details the end-to-end release process for the `soroban-budget-assert` project, including pre-release preparation, version bumping mechanics, crate publish ordering, automated GitHub Actions CI workflows, verification, and failure recovery.
+
+The canonical source of truth for the automated release pipeline is [`.github/workflows/release.yml`](https://github.com/Tollcraft/soroban-budget-assert/blob/main/.github/workflows/release.yml).
+
+---
+
+## 📦 Architecture & Packages
+
+The repository is organized as a Cargo workspace publishing two crates to crates.io and cross-platform CLI binaries:
+
+| Package | Crates.io Name | Role | Release Artifacts |
+|---|---|---|---|
+| `budget-macros` | `budget-macros` | Procedural macro crate (`#[budget_cpu_lt]`, `#[budget_mem_lt]`) | Published to crates.io |
+| `cargo-budget-report` | `cargo-budget-report` | CLI tool and cargo subcommand for resource reporting | Published to crates.io + pre-compiled binaries on GitHub Releases |
+| `budget-core` | `soroban-budget-assert-core` | Internal core library (not published to crates.io, `publish = false`) | Workspace dependency |
+| `amm-pool-contract` | `amm-pool-contract` | Benchmark contract fixture (not published, `publish = false`) | Test fixture |
+
+### Workspace Versioning
+
+All member crates inherit their version from the workspace root manifest (`Cargo.toml`) via:
+
+```toml
+[package]
+version.workspace = true
+```
+
+The single source of truth for the version is defined under `[workspace.package]` in the root [`Cargo.toml`](https://github.com/Tollcraft/soroban-budget-assert/blob/main/Cargo.toml):
+
+```toml
+[workspace.package]
+version = "0.1.0"
+```
+
+When bumping versions, only `[workspace.package].version` in root `Cargo.toml` needs to be updated. All workspace crates advance in lockstep.
+
+### Crate Publish Ordering
+
+When publishing to crates.io, publishing order matters:
+
+1. **`budget-macros`** is published **first**.
+2. **`cargo-budget-report`** is published **second**.
+
+**Why ordering matters:** `budget-macros` is an independent proc-macro crate with no workspace dependencies. Downstream crates or contracts that consume the macros or CLI depend on the macro crate being resolvable on crates.io. Publishing `budget-macros` first ensures that the macro definitions are available on the registry before the toolchain or downstream packages resolve against that version.
+
+---
+
+## ✅ Pre-Release Checklist
+
+Before creating a release tag, complete the following steps on `main`:
+
+1. **Working Tree Cleanliness:** Ensure all intended feature and bugfix PRs are merged into `main`.
+2. **Update `CHANGELOG.md`:**
+   - Move changes from the `## Unreleased` section into a new version header: `## [vX.Y.Z] - YYYY-MM-DD`.
+   - Ensure all user-facing changes, bug fixes, and breaking changes are documented according to [Keep a Changelog](https://keepachangelog.com/).
+3. **Bump Workspace Version:**
+   - Update `version = "X.Y.Z"` under `[workspace.package]` in `Cargo.toml`.
+   - Run `cargo check --workspace` to update `Cargo.lock` with the new version.
+4. **Run Quality Gates Locally:**
+   ```bash
+   cargo fmt --all -- --check
+   cargo clippy --workspace --all-targets -- -D warnings
+   cargo test --workspace
+   ```
+5. **Verify PR Dry-Run CI:**
+   - On every pull request targeting `main`, `.github/workflows/release.yml` automatically runs the `publish-dry-run` job:
+     ```bash
+     cargo publish -p budget-macros --dry-run
+     cargo publish -p cargo-budget-report --dry-run
+     ```
+   - Ensure the dry-run check is green before merging the version bump PR to `main`.
+
+---
+
+## 🏷️ Cutting a Release
+
+Once the version bump is merged into `main`:
+
+1. **Create an Annotated Git Tag:**
+   Tags must follow the `vX.Y.Z` naming convention (matching the version in `Cargo.toml` prefixed with `v`):
+   ```bash
+   git checkout main
+   git pull origin main
+   git tag -a v0.1.0 -m "Release v0.1.0"
+   ```
+
+2. **Push the Tag to GitHub:**
+   ```bash
+   git push origin v0.1.0
+   ```
+
+Pushing the `v*` tag triggers the automated release workflow in GitHub Actions.
+
+---
+
+## 🤖 What CI Does Automatically
+
+When a tag matching `v*` is pushed, [`.github/workflows/release.yml`](https://github.com/Tollcraft/soroban-budget-assert/blob/main/.github/workflows/release.yml) executes three automated jobs in parallel/sequence:
+
+```mermaid
+graph TD
+    Tag["Push tag vX.Y.Z"] --> Build["Job: build (matrix)"]
+    Build --> BinLinux["Linux x86_64: cargo-budget-report-linux-amd64"]
+    Build --> BinMacIntel["macOS x86_64: cargo-budget-report-macos-amd64"]
+    Build --> BinMacArm["macOS ARM64: cargo-budget-report-macos-arm64"]
+    Build --> BinWin["Windows x86_64: cargo-budget-report-windows-amd64.exe"]
+
+    BinLinux --> Checksums["Job: checksums (needs build)"]
+    BinMacIntel --> Checksums
+    BinMacArm --> Checksums
+    BinWin --> Checksums
+
+    Checksums --> GHRelease["GitHub Release with 4 binaries + SHA256SUMS"]
+
+    Build --> Publish["Job: publish to crates.io (needs build)"]
+    Publish --> VerifyTag["Verify tag vX.Y.Z matches Cargo.toml version"]
+    VerifyTag --> PubMacros["cargo publish -p budget-macros"]
+    PubMacros --> PubCLI["cargo publish -p cargo-budget-report"]
+```
+
+### 1. `build` Job (Matrix across 4 targets)
+Compiles `cargo-budget-report` in `--release` mode for four architectures:
+- `x86_64-unknown-linux-gnu` (Ubuntu latest, installs `libdbus-1-dev`, `pkg-config`, `libudev-dev`) → `cargo-budget-report-linux-amd64`
+- `x86_64-apple-darwin` (macOS latest Intel) → `cargo-budget-report-macos-amd64`
+- `aarch64-apple-darwin` (macOS latest Apple Silicon) → `cargo-budget-report-macos-arm64`
+- `x86_64-pc-windows-msvc` (Windows latest) → `cargo-budget-report-windows-amd64.exe`
+
+Each binary is uploaded as a workflow artifact.
+
+### 2. `checksums` Job (runs after `build`)
+- Downloads all binary artifacts.
+- Generates `SHA256SUMS` with `sha256sum cargo-budget-report-* > SHA256SUMS`.
+- Creates or updates a GitHub Release for the tag using `softprops/action-gh-release@v3`, attaching all four binaries and the `SHA256SUMS` file.
+
+### 3. `publish` Job (runs after `build`)
+- Validates that the git tag version strictly matches the workspace version in `Cargo.toml`:
+  ```bash
+  TAG_VERSION="${GITHUB_REF_NAME#v}"
+  WORKSPACE_VERSION=$(awk '/^\[workspace\.package\]/ {found=1} found && /^version = / {print; exit}' Cargo.toml | sed 's/.*= "\(.*\)"/\1/')
+  if [ "$TAG_VERSION" != "$WORKSPACE_VERSION" ]; then
+    echo "ERROR: Tag v$TAG_VERSION does not match workspace version $WORKSPACE_VERSION"
+    exit 1
+  fi
+  ```
+- Publishes `budget-macros` to crates.io using the secret `CARGO_REGISTRY_TOKEN`.
+- Publishes `cargo-budget-report` to crates.io using the secret `CARGO_REGISTRY_TOKEN`.
+
+---
+
+## 🔍 Post-Release Verification
+
+After the GitHub Actions workflow finishes:
+
+1. **Verify GitHub Release:**
+   - Navigate to the repository Releases page: `https://github.com/Tollcraft/soroban-budget-assert/releases/tag/vX.Y.Z`.
+   - Confirm the release tag exists and contains the 4 pre-compiled binaries and `SHA256SUMS`.
+   - Test downloading a binary and verifying checksum:
+     ```bash
+     sha256sum -c SHA256SUMS
+     ```
+
+2. **Verify Crates.io:**
+   - Check `https://crates.io/crates/budget-macros` shows the new version.
+   - Check `https://crates.io/crates/cargo-budget-report` shows the new version.
+
+3. **Verify Installation:**
+   - Install the new version from crates.io:
+     ```bash
+     cargo install cargo-budget-report --version X.Y.Z
+     cargo budget-report --version
+     ```
+
+---
+
+## 🛠️ Troubleshooting & Failure Recovery
+
+A release failure can occur either before or after packages are published to crates.io. Because **crates.io is immutable** (published versions cannot be replaced, overwritten, or deleted), recovery depends on when the failure occurred.
+
+### Scenario A: Failure *Before* crates.io Publish
+*(e.g., Matrix build failure, system dependency issue, or tag mismatch)*
+
+1. No crate was published to crates.io.
+2. Delete the local and remote git tag:
+   ```bash
+   git tag -d vX.Y.Z
+   git push origin :refs/tags/vX.Y.Z
+   ```
+3. Fix the underlying issue on a feature branch, merge to `main`, and re-tag `vX.Y.Z`.
+
+### Scenario B: Failure *During or After* crates.io Publish
+*(e.g., `budget-macros` published successfully, but `cargo-budget-report` failed, or a critical defect was discovered immediately post-release)*
+
+1. **Do NOT delete the tag or attempt to re-publish the same version.** Crates.io will reject any attempt to re-upload the same version number.
+2. **If a broken crate version was published:**
+   Yank the affected release to prevent new projects from resolving it while preserving builds for existing lockfiles:
+   ```bash
+   cargo yank --version X.Y.Z budget-macros
+   cargo yank --version X.Y.Z cargo-budget-report
+   ```
+3. **Cut a Patch Release:**
+   - Bump `version = "X.Y.(Z+1)"` under `[workspace.package]` in `Cargo.toml`.
+   - Document the fix in `CHANGELOG.md` under `## [vX.Y.(Z+1)]`.
+   - Run quality checks and merge the fix to `main`.
+   - Cut and push the new tag `vX.Y.(Z+1)`.
+
+---
+
+## 📋 Release Summary Table
+
+| Step | Action | Responsibility |
+|---|---|---|
+| 1 | Update `CHANGELOG.md` & bump `[workspace.package].version` in `Cargo.toml` | Maintainer (PR to `main`) |
+| 2 | Validate `cargo publish --dry-run` on both crates | CI (`publish-dry-run` job) |
+| 3 | Create and push git tag `vX.Y.Z` | Maintainer |
+| 4 | Build 4 platform binaries & generate `SHA256SUMS` | CI (`build` & `checksums` jobs) |
+| 5 | Create GitHub Release with attached assets | CI (`checksums` job) |
+| 6 | Publish `budget-macros` then `cargo-budget-report` to crates.io | CI (`publish` job) |
+| 7 | Verify crates.io and GitHub Releases | Maintainer |

--- a/site/README.md
+++ b/site/README.md
@@ -1,22 +1,23 @@
 # Soroban Budget Assert Landing Page
 
-This directory contains the source code for the official `soroban-budget-assert` landing page.
+This directory contains the source code for the official `soroban-budget-assert` landing page and cost-over-time dashboard.
 
 ## 🚀 Overview
 
-The landing page is a lightweight, responsive, single-page website built with standard static HTML5, CSS3, and JavaScript. It has zero external build or runtime dependencies, making it simple and maintainable for Rust developers.
+The site is a lightweight, responsive static web application built with standard HTML5, CSS3, and vanilla JavaScript. It requires no build step (zero build tooling dependencies), making it simple and maintainable. Runtime assets include Google Fonts for typography on the landing page and Chart.js loaded from CDN on the dashboard page.
 
 ### Structure
 
-- `index.html`: Main single-page document containing hero section, problem statement, cost-gap comparison metrics, two-tier architecture overview, quick start code blocks, asciinema demo embed, and community links.
-- `styles.css`: Custom CSS styles including design system tokens, responsive grid layouts, animations, and dark mode aesthetics.
-- `dashboard.html`: Cost-over-time dashboard that visualises the budget history dataset.
-- `assets/dashboard.js`: Dashboard data fetching and chart rendering logic.
-- `assets/dashboard.css`: Dashboard-specific styles.
+- `index.html`: Main single-page landing page document containing the hero section, problem statement, cost-gap comparison metrics, two-tier architecture overview, quick start code blocks, asciinema demo embed, and community links.
+- `styles.css`: Custom CSS styles for the landing page including design system tokens, responsive grid layouts, animations, and dark mode aesthetics.
+- `dashboard.html`: Cost-over-time dashboard that visualizes the budget history dataset across packages, functions, and metrics.
+- `assets/dashboard.css`: Dashboard-specific layout and styles for charts, controls, and selectors.
+- `assets/dashboard.js`: Client-side data fetching, metric filtering, series pivoting, and Chart.js rendering logic.
+- `README.md`: Directory overview, file inventory, local development instructions, and deployment details.
 
 ## 🛠️ Local Development & Preview
 
-Since the site consists of static files, you can view it directly by opening `index.html` in any web browser, or serve it using any simple static HTTP server:
+Since the site consists of static files, you can view it directly by opening `index.html` or `dashboard.html` in any web browser, or serve it using any simple static HTTP server:
 
 ```bash
 # Using Python
@@ -26,10 +27,17 @@ python3 -m http.server 8000 --directory site
 npx serve site
 ```
 
-Then visit `http://localhost:8000` in your browser.
+Then visit `http://localhost:8000` (landing page) or `http://localhost:8000/dashboard.html` (dashboard) in your browser.
 
 ## 🚢 Deployment
 
-The site is automatically deployed to GitHub Pages (`gh-pages` root) via GitHub Actions whenever changes are merged into `main`.
+The site is automatically deployed to GitHub Pages (`gh-pages` root) via GitHub Actions whenever changes to `site/**` are merged into `main`.
 
-Deployment workflow: `.github/workflows/deploy-site.yml`.
+Deployment workflow: [`.github/workflows/deploy-site.yml`](../.github/workflows/deploy-site.yml).
+
+### How the deployment pieces fit together
+
+1. **`budget.yml` (`record-history` job)**: On every push to `main`, runs contract simulations and appends `{commit, timestamp, data}` entries to `history.json` on the `gh-pages` branch.
+2. **`deploy-site.yml`**: Publishes the contents of `site/` to `gh-pages` using `peaceiris/actions-gh-pages` with `keep_files: true`, so `history.json` is never deleted or overwritten. Both workflows share the `gh-pages-deploy` concurrency group to prevent race conditions on the `gh-pages` branch.
+3. **Client-side Dashboard**: The dashboard page (`dashboard.html`) fetches `history.json` same-origin and pivots the data client-side into `package → function → metric` series — requiring no backend server or build-time data baking.
+


### PR DESCRIPTION
## Summary of Changes

This PR resolves four documentation, diagram, and workflow reference issues across the repository:

### 1. Fix `site/README.md` deploy workflow documentation and incomplete file list (#511)
- **File inventory**: Updated `site/README.md` to list and describe all six files in `site/` (`index.html`, `styles.css`, `dashboard.html`, `assets/dashboard.css`, `assets/dashboard.js`, and `README.md`).
- **Dependencies clarification**: Clarified that the static site requires no build step (zero build tooling dependencies), while accurately identifying runtime CDN assets (Google Fonts on the landing page and Chart.js on the dashboard).
- **Deployment architecture**: Updated deployment documentation to reference `.github/workflows/deploy-site.yml` and documented the three-part deployment chain (how `budget.yml` appends to `history.json` on `gh-pages`, `deploy-site.yml` deploys static assets with `keep_files: true` under the `gh-pages-deploy` concurrency group, and the dashboard fetches `history.json` client-side).

### 2. Fix Mermaid architecture diagrams rendering literal `\n` (#508)
- Replaced literal `\n` characters with supported `<br/>` line break tags in Mermaid message and node labels across:
  - `architecture/cargo-budget-report-pipeline.mmd`
  - `architecture/budget-cpu-lt-macro-expansion.mmd`
  - `architecture/README.md`
- Ensured node labels with `<br/>` in flowchart diagrams are properly quoted.
- Verified exact 1-to-1 parity between the `.mmd` source files and the embedded Mermaid diagrams in `architecture/README.md`.

### 3. Restructure documentation Table of Contents and fix out-of-tree link (#462)
- **Table of Contents reorganization**: Restructured `docs/src/SUMMARY.md` into logical, sequential sections (*Getting Started*, *Guides & Tutorials*, *Reference & Architecture*, and *Developer & Contributing*).
- **In-tree measurements document**: Created `docs/src/measurements.md` containing the complete methodology, cost-gap tables, and SDK calibration figures, ensuring GitBook builds (which use `root: ./docs/src/`) resolve cleanly without escaping the book root.
- **Internal link fixes**: Updated links across `docs/src/mechanics.md`, `docs/src/ci_tutorial.md`, and `docs/src/ci_cd_integration.md` to point to `measurements.md`.
- Cleaned up stray merge markers in the root `MEASUREMENTS.md`.

### 4. Document the Release Process (#465)
- **Release guide**: Created `docs/src/release_process.md` detailing the complete end-to-end release lifecycle derived directly from `.github/workflows/release.yml` and root `Cargo.toml`.
- **Workspace versioning & publish order**: Documented workspace version inheritance (`version.workspace = true`), single-point version bumping under `[workspace.package].version`, and explicit crate publish ordering (`budget-macros` first, then `cargo-budget-report` second) with dependency rationale.
- **Checklists & workflows**: Included a pre-release checklist, PR dry-run publish validation, tag naming rules (`vX.Y.Z`), 4-target binary matrix builds (`linux-amd64`, `macos-amd64`, `macos-arm64`, `windows-amd64`), `SHA256SUMS` generation, GitHub Release creation, crates.io publishing, post-release verification, and failure recovery / rollback procedures (crates.io immutability, patch bumps, and `cargo yank`).
- Linked the release guide in `docs/src/SUMMARY.md`.

---

## Linked Issues

Closes #511
Closes #508
Closes #462
Closes #465