### PR TITLE
feat: configurable retry policy shared by deploy, invoke-build, and simulate RPC (Closes #456)

### DIFF
--- a/cargo-budget-report/src/cli.rs
+++ b/cargo-budget-report/src/cli.rs
@@ -142,4 +142,17 @@ pub struct BudgetReportArgs {
     /// `tier-a-limits.provenance.md` for `tier-a-limits.env`).
     #[arg(long, value_name = "PATH")]
     pub provenance_out: Option<String>,
+
+    /// Maximum number of attempts (including the first) for deploy,
+    /// invoke-build, and simulate-RPC calls before giving up. `1`
+    /// disables retry entirely. Overrides `retry.max_attempts` in
+    /// `budget.toml`; defaults to 4.
+    #[arg(long, value_name = "N")]
+    pub max_retry_attempts: Option<u32>,
+
+    /// Initial backoff, in seconds, before the first retry. Doubles on
+    /// each subsequent attempt (2 → 4 → 8). Overrides
+    /// `retry.initial_backoff_secs` in `budget.toml`; defaults to 2.
+    #[arg(long, value_name = "SECS")]
+    pub retry_backoff_secs: Option<u64>,
 }

--- a/cargo-budget-report/src/main.rs
+++ b/cargo-budget-report/src/main.rs
@@ -35,6 +35,170 @@ const MAX_DEPLOY_ATTEMPTS: u32 = 4;
 /// subsequent attempt (2 s → 4 s → 8 s).
 const INITIAL_RETRY_DELAY_SECS: u64 = 2;
 
+/// `[retry]` section of `budget.toml`.
+///
+/// Both fields are optional; missing values fall back to the built-in
+/// defaults (`MAX_DEPLOY_ATTEMPTS` / `INITIAL_RETRY_DELAY_SECS`).
+#[derive(serde::Deserialize, Default, Debug, Clone, Copy)]
+struct RetryToml {
+    #[serde(default)]
+    max_attempts: Option<u32>,
+    #[serde(default)]
+    initial_backoff_secs: Option<u64>,
+}
+
+/// Fully resolved retry policy: CLI over `budget.toml` over defaults.
+///
+/// The worst-case total sleep for one call site is bounded and derivable
+/// from this struct: `initial_backoff * (2^(max_attempts - 1) - 1)`.
+/// With the defaults (4 attempts, 2 s initial) that is 2 + 4 + 8 = 14 s.
+#[derive(Debug, Clone, Copy)]
+struct RetryConfig {
+    /// Total attempts including the first. A value of 1 disables retry.
+    max_attempts: u32,
+    initial_backoff: Duration,
+}
+
+impl Default for RetryConfig {
+    fn default() -> Self {
+        RetryConfig {
+            max_attempts: MAX_DEPLOY_ATTEMPTS,
+            initial_backoff: Duration::from_secs(INITIAL_RETRY_DELAY_SECS),
+        }
+    }
+}
+
+impl RetryConfig {
+    /// True when retry is disabled (a single attempt is made).
+    fn disabled(&self) -> bool {
+        self.max_attempts <= 1
+    }
+}
+
+/// Resolves the effective retry policy: CLI flags win over the
+/// `budget.toml` `[retry]` section, which wins over the defaults.
+fn resolve_retry_config(
+    cli_max_attempts: Option<u32>,
+    cli_backoff_secs: Option<u64>,
+    toml_retry: Option<RetryToml>,
+) -> Result<RetryConfig> {
+    let mut config = RetryConfig::default();
+    if let Some(retry) = toml_retry {
+        if let Some(attempts) = retry.max_attempts {
+            config.max_attempts = attempts;
+        }
+        if let Some(secs) = retry.initial_backoff_secs {
+            config.initial_backoff = Duration::from_secs(secs);
+        }
+    }
+    if let Some(attempts) = cli_max_attempts {
+        config.max_attempts = attempts;
+    }
+    if let Some(secs) = cli_backoff_secs {
+        config.initial_backoff = Duration::from_secs(secs);
+    }
+    if config.max_attempts == 0 {
+        return Err(Error::Message(
+            "retry max_attempts must be at least 1 (1 disables retry)".into(),
+        ));
+    }
+    Ok(config)
+}
+
+/// Why a single attempt failed, from the point of view of the retry loop.
+///
+/// Only [`RetryFailure::Transient`] failures are retried; a
+/// [`RetryFailure::Permanent`] failure aborts immediately because
+/// repeating it cannot change the outcome.
+enum RetryFailure {
+    /// Plausibly transient: rate-limit responses, connection errors,
+    /// timeouts. Worth retrying after a backoff.
+    Transient(String),
+    /// Deterministic: a contract that does not exist, a malformed XDR,
+    /// an RPC-reported simulation error. Retrying would only make the
+    /// run slower before failing anyway.
+    Permanent(String),
+}
+
+/// Heuristically classifies an error message as plausibly transient.
+///
+/// Retried: rate-limit / HTTP-429 style responses ("rate limit",
+/// "rate-limited", "429", "too many requests"), connection-level
+/// failures ("connection", "timed out", "timeout", "reset by peer",
+/// "broken pipe", "network"), server-side blips ("503", "502", "504",
+/// "unavailable", "temporarily", "try again").
+///
+/// Everything else — unknown errors included — is treated as permanent.
+/// A conservative whitelist keeps deterministic failures (missing
+/// contract, malformed XDR, simulation errors) from being retried four
+/// times before failing anyway.
+fn is_transient_error(message: &str) -> bool {
+    const TRANSIENT_MARKERS: [&str; 15] = [
+        "rate limit",
+        "rate-limited",
+        "ratelimit",
+        "429",
+        "too many requests",
+        "connection",
+        "timed out",
+        "timeout",
+        "reset by peer",
+        "broken pipe",
+        "503",
+        "502",
+        "unavailable",
+        "temporarily",
+        "try again",
+    ];
+    let lowered = message.to_ascii_lowercase();
+    TRANSIENT_MARKERS.iter().any(|m| lowered.contains(m))
+}
+
+/// Runs `op` up to `config.max_attempts` times with exponential backoff.
+///
+/// Backoff sleeps `config.initial_backoff` before the second attempt and
+/// doubles on each further attempt, so the worst-case total sleep is
+/// `initial_backoff * (2^(max_attempts - 1) - 1)` — bounded and
+/// predictable from configuration alone.
+///
+/// Progress messages go to stderr unless `quiet` is set. When every
+/// attempt fails, `exhausted` builds the final error from the last
+/// transient error message so each call site can keep its own wording.
+fn run_with_retry<T, Op, ErrFn>(
+    config: &RetryConfig,
+    quiet: bool,
+    label: &str,
+    mut op: Op,
+    exhausted: ErrFn,
+) -> Result<T>
+where
+    Op: FnMut() -> std::result::Result<T, RetryFailure>,
+    ErrFn: FnOnce(&str) -> Error,
+{
+    let mut last_error = String::new();
+
+    for attempt in 0..config.max_attempts {
+        if attempt > 0 {
+            let delay_secs = config.initial_backoff.as_secs() * 2u64.pow(attempt - 1);
+            if !quiet {
+                eprintln!(
+                    "{label} attempt {}/{} failed. Retrying in {} s...",
+                    attempt, config.max_attempts, delay_secs
+                );
+            }
+            thread::sleep(Duration::from_secs(delay_secs));
+        }
+
+        match op() {
+            Ok(value) => return Ok(value),
+            Err(RetryFailure::Transient(err)) => last_error = err,
+            Err(RetryFailure::Permanent(err)) => return Err(exhausted(&err)),
+        }
+    }
+
+    Err(exhausted(&last_error))
+}
+
 /// Commented budget.toml template written by `cargo budget-report --init`.
 const BUDGET_TOML_TEMPLATE: &str = r#"# -- Budget report configuration ---------------------------------------------
 # Generated by `cargo budget-report --init`.
@@ -93,6 +257,10 @@ struct BudgetToml {
     scenarios: HashMap<String, ScenarioToml>,
     #[serde(default)]
     functions: HashMap<String, FunctionConfig>,
+    /// `[retry]` section controlling deploy / simulate / invoke-build
+    /// retry behavior. Absent means "use the built-in defaults".
+    #[serde(default)]
+    retry: Option<RetryToml>,
 }
 
 /// Per-metric margin multipliers persisted in `budget.toml`.
@@ -456,16 +624,19 @@ fn build_rpc_payload(b64_xdr: &str) -> serde_json::Value {
 }
 
 /// POSTs a `simulateTransaction` JSON-RPC request for `b64_xdr` and returns
-/// the parsed response body.
+/// the parsed response body, classified as [`RetryFailure`] so the retry
+/// wrapper can decide whether to attempt again.
 ///
 /// Uses `curl` to send the request to the Soroban RPC endpoint. The
 /// request body is piped via stdin to avoid shell-quoting issues.
 ///
 /// # Errors
 ///
-/// Returns an error if `curl` cannot be spawned, the request fails, or
-/// the response body is not valid JSON.
-fn simulate_transaction_rpc(b64_xdr: &str) -> Result<serde_json::Value> {
+/// Returns a *permanent* [`RetryFailure`] if `curl` cannot be spawned or
+/// its stdio cannot be wired up (environment problems retrying cannot
+/// fix), and a *transient* one for connection-level failures (non-zero
+/// curl exit) or an unparseable response body.
+fn simulate_transaction_rpc(b64_xdr: &str) -> std::result::Result<serde_json::Value, RetryFailure> {
     let rpc_payload = build_rpc_payload(b64_xdr);
 
     let mut curl = Command::new("curl")
@@ -482,60 +653,148 @@ fn simulate_transaction_rpc(b64_xdr: &str) -> Result<serde_json::Value> {
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .spawn()
-        .map_err(|e| Error::CommandFailed(format!("failed to execute curl: {}", e)))?;
+        .map_err(|e| {
+            // A missing/unspawnable `curl` is an environment problem,
+            // not something a retry can fix.
+            RetryFailure::Permanent(format!("failed to execute curl: {}", e))
+        })?;
 
     {
         let stdin = curl
             .stdin
             .as_mut()
-            .ok_or_else(|| Error::CommandFailed("Failed to open stdin".into()))?;
+            .ok_or_else(|| RetryFailure::Permanent("Failed to open stdin".to_string()))?;
         stdin
             .write_all(rpc_payload.to_string().as_bytes())
-            .map_err(|e| Error::CommandFailed(format!("failed to write to stdin: {}", e)))?;
+            .map_err(|e| RetryFailure::Permanent(format!("failed to write to stdin: {}", e)))?;
     }
 
     let curl_output = curl
         .wait_with_output()
-        .map_err(|e| Error::CommandFailed(format!("failed to read curl output: {}", e)))?;
-    serde_json::from_slice(&curl_output.stdout)
-        .map_err(|e| Error::Message(format!("Failed to parse RPC response: {}", e)))
+        .map_err(|e| RetryFailure::Permanent(format!("failed to read curl output: {}", e)))?;
+
+    if !curl_output.status.success() {
+        // Connection refused, DNS failure, TLS errors, HTTP-level
+        // failures surfaced by `curl -s`: all plausibly transient.
+        return Err(RetryFailure::Transient(format!(
+            "curl exited with status {}: {}",
+            curl_output.status,
+            String::from_utf8_lossy(&curl_output.stderr).trim()
+        )));
+    }
+
+    serde_json::from_slice(&curl_output.stdout).map_err(|e| {
+        // An empty or truncated body almost always means the
+        // connection dropped mid-response; treat it as transient.
+        RetryFailure::Transient(format!("Failed to parse RPC response: {}", e))
+    })
+}
+
+/// POSTs the `simulateTransaction` request with retry on plausibly
+/// transient failures (connection errors, rate limits). Deterministic
+/// failures such as an unspawnable `curl` are not retried.
+///
+/// Exhausting every attempt remains fatal (the run aborts), matching the
+/// pre-retry behavior where an RPC transport failure failed the whole run.
+fn simulate_transaction_rpc_with_retry(
+    b64_xdr: &str,
+    retry_config: &RetryConfig,
+    quiet: bool,
+) -> Result<serde_json::Value> {
+    run_with_retry(
+        retry_config,
+        quiet,
+        "Simulate RPC request",
+        || simulate_transaction_rpc(b64_xdr),
+        |last_error| {
+            Error::Message(format!(
+                "Simulate RPC request failed after {} attempts.\nLast error: {}",
+                retry_config.max_attempts, last_error
+            ))
+        },
+    )
+}
+
+/// Builds the unsigned transaction XDR for one function via
+/// `stellar contract invoke --build-only`, retrying on plausibly
+/// transient failures.
+///
+/// Non-zero exits whose stderr looks transient (rate limits, connection
+/// errors) are retried; deterministic failures — a missing contract ID,
+/// a rejected argument, a spawn failure of the `stellar` binary — are
+/// not, because repeating them cannot change the outcome. Exhaustion is
+/// reported as an error carrying the final stderr so callers can keep
+/// their existing recoverable-failure handling.
+fn build_invoke_xdr_with_retry(
+    invoke_args: &[String],
+    retry_config: &RetryConfig,
+    quiet: bool,
+) -> Result<String> {
+    run_with_retry(
+        retry_config,
+        quiet,
+        "Invoke build",
+        || {
+            let invoke_output =
+                Command::new("stellar")
+                    .args(invoke_args)
+                    .output()
+                    .map_err(|e| {
+                        RetryFailure::Permanent(format!(
+                            "failed to execute stellar-cli invoke: {}",
+                            e
+                        ))
+                    })?;
+
+            if !invoke_output.status.success() {
+                let stderr = String::from_utf8_lossy(&invoke_output.stderr).to_string();
+                return if is_transient_error(&stderr) {
+                    Err(RetryFailure::Transient(stderr))
+                } else {
+                    Err(RetryFailure::Permanent(stderr))
+                };
+            }
+
+            Ok(String::from_utf8_lossy(&invoke_output.stdout)
+                .trim()
+                .to_string())
+        },
+        |last_error| Error::Message(last_error.to_string()),
+    )
 }
 
 /// Simulates one exported function end-to-end: runs
-/// `stellar contract invoke --build-only` to build the transaction, then
-/// POSTs it to `simulateTransaction` and decodes the reported resource
-/// usage.
+/// `stellar contract invoke --build-only` to build the transaction (with
+/// retry), then POSTs it to `simulateTransaction` (with retry) and decodes
+/// the reported resource usage.
 ///
-/// Returns `Err` only for a spawn/IO failure on the `stellar`/`curl` child
-/// processes — the tool cannot proceed without those binaries. A
+/// Returns `Err` only for a persistent RPC transport failure after every
+/// retry attempt is exhausted, or for an unrecoverable environment
+/// problem — the tool cannot proceed without those binaries. A
 /// *recoverable* simulation failure (non-zero invoke exit, an RPC `error`
 /// field, or an undecodable response) is reported as
 /// `Ok(SimulationOutcome::Failed(..))` so the caller can move on to the next
 /// function instead of aborting the whole report.
+#[allow(clippy::too_many_arguments)]
 fn simulate_function(
     contract_id: &str,
     source: &str,
     network: &str,
     function: &str,
     func_args: &[String],
+    retry_config: &RetryConfig,
+    quiet: bool,
 ) -> Result<SimulationOutcome> {
     let invoke_args = build_invoke_args(contract_id, source, network, function, func_args);
-    let invoke_output = Command::new("stellar")
-        .args(&invoke_args)
-        .output()
-        .map_err(|e| {
-            Error::CommandFailed(format!("failed to execute stellar-cli invoke: {}", e))
-        })?;
-
-    if !invoke_output.status.success() {
-        let stderr = String::from_utf8_lossy(&invoke_output.stderr).to_string();
-        return Ok(SimulationOutcome::Failed(SimulationFailure::Invoke(stderr)));
-    }
-
-    let b64_xdr = String::from_utf8_lossy(&invoke_output.stdout)
-        .trim()
-        .to_string();
-    let rpc_resp = simulate_transaction_rpc(&b64_xdr)?;
+    let b64_xdr = match build_invoke_xdr_with_retry(&invoke_args, retry_config, quiet) {
+        Ok(xdr) => xdr,
+        Err(err) => {
+            return Ok(SimulationOutcome::Failed(SimulationFailure::Invoke(
+                format!("{:#}", err),
+            )));
+        }
+    };
+    let rpc_resp = simulate_transaction_rpc_with_retry(&b64_xdr, retry_config, quiet)?;
 
     if let Some(error) = rpc_resp.get("error") {
         return Ok(SimulationOutcome::Failed(SimulationFailure::Rpc(
@@ -808,58 +1067,67 @@ fn run_preflight_checks(quiet: bool) -> Result<()> {
 /// The `stellar contract deploy` command implicitly triggers friendbot
 /// funding for the source account on testnet. Friendbot may return 429
 /// (rate-limited) or the account may not be confirmed on-ledger yet.
-/// This function makes up to `MAX_DEPLOY_ATTEMPTS` total attempts with
-/// exponential backoff before giving up.
+/// This function makes up to `retry_config.max_attempts` total attempts
+/// with exponential backoff before giving up — but only when the deploy
+/// stderr looks plausibly transient (rate limits, connection errors).
+/// Deterministic failures are not retried.
 fn deploy_contract_with_retry(
     wasm_path: &Path,
     source: &str,
     network: &str,
     package_name: &str,
+    retry_config: &RetryConfig,
+    quiet: bool,
 ) -> Result<String> {
-    let mut last_error = String::new();
+    let wasm_path_str = wasm_path
+        .to_str()
+        .ok_or_else(|| Error::Message("wasm path is not valid UTF-8".into()))?
+        .to_string();
 
-    for attempt in 0..MAX_DEPLOY_ATTEMPTS {
-        if attempt > 0 {
-            let delay = INITIAL_RETRY_DELAY_SECS * 2u64.pow(attempt - 1);
-            eprintln!(
-                "Deploy attempt {}/{} failed. Retrying in {} s...",
-                attempt, MAX_DEPLOY_ATTEMPTS, delay
-            );
-            thread::sleep(Duration::from_secs(delay));
-        }
+    run_with_retry(
+        retry_config,
+        quiet,
+        "Deploy",
+        || {
+            let deploy_output = Command::new("stellar")
+                .args([
+                    "contract",
+                    "deploy",
+                    "--wasm",
+                    &wasm_path_str,
+                    "--source",
+                    source,
+                    "--network",
+                    network,
+                ])
+                .output()
+                .map_err(|e| {
+                    // A missing/unspawnable `stellar` binary is an
+                    // environment problem, not something a retry fixes.
+                    RetryFailure::Permanent(format!("failed to execute stellar-cli deploy: {}", e))
+                })?;
 
-        let deploy_output = Command::new("stellar")
-            .args([
-                "contract",
-                "deploy",
-                "--wasm",
-                wasm_path
-                    .to_str()
-                    .ok_or_else(|| Error::Message("wasm path is not valid UTF-8".into()))?,
-                "--source",
-                source,
-                "--network",
-                network,
-            ])
-            .output()
-            .map_err(|e| {
-                Error::CommandFailed(format!("failed to execute stellar-cli deploy: {}", e))
-            })?;
+            if deploy_output.status.success() {
+                let contract_id = String::from_utf8_lossy(&deploy_output.stdout)
+                    .trim()
+                    .to_string();
+                return Ok(contract_id);
+            }
 
-        if deploy_output.status.success() {
-            let contract_id = String::from_utf8_lossy(&deploy_output.stdout)
-                .trim()
-                .to_string();
-            return Ok(contract_id);
-        }
-
-        last_error = String::from_utf8_lossy(&deploy_output.stderr).to_string();
-    }
-
-    Err(Error::Message(format!(
-        "Failed to deploy {} after {} attempts. Ensure your source account is funded.\nLast error: {}",
-        package_name, MAX_DEPLOY_ATTEMPTS, last_error
-    )))
+            let stderr = String::from_utf8_lossy(&deploy_output.stderr).to_string();
+            if is_transient_error(&stderr) {
+                Err(RetryFailure::Transient(stderr))
+            } else {
+                Err(RetryFailure::Permanent(stderr))
+            }
+        },
+        |last_error| {
+            Error::Message(format!(
+                "Failed to deploy {} after {} attempts. Ensure your source account is funded.\nLast error: {}",
+                package_name, retry_config.max_attempts, last_error
+            ))
+        },
+    )
 }
 
 fn run_derive_mode(args: &BudgetReportArgs, toml_config: &BudgetToml) -> Result<()> {
@@ -1104,6 +1372,16 @@ fn main() -> anyhow::Result<()> {
         .or(toml_config.source.clone())
         .context("missing --source or budget.toml source field")?;
 
+    let retry_config = resolve_retry_config(
+        args.max_retry_attempts,
+        args.retry_backoff_secs,
+        toml_config.retry,
+    )
+    .context("failed to resolve retry configuration")?;
+    if retry_config.disabled() && !args.quiet {
+        eprintln!("Retry is disabled (--max-retry-attempts 1): each call gets a single attempt.");
+    }
+
     if !args.quiet {
         eprintln!("Discovering workspace members...");
     }
@@ -1228,8 +1506,14 @@ fn main() -> anyhow::Result<()> {
             Some(pb)
         };
 
-        let contract_id =
-            deploy_contract_with_retry(wasm_path.as_std_path(), &source, &network, &package.name)?;
+        let contract_id = deploy_contract_with_retry(
+            wasm_path.as_std_path(),
+            &source,
+            &network,
+            &package.name,
+            &retry_config,
+            args.quiet,
+        )?;
 
         if let Some(spinner) = spinner {
             spinner.finish_and_clear();
@@ -1245,7 +1529,15 @@ fn main() -> anyhow::Result<()> {
             let func_config = toml_config.functions.get(&function);
             let func_args = func_config.map(|cfg| cfg.args.clone()).unwrap_or_default();
 
-            match simulate_function(&contract_id, &source, &network, &function, &func_args)? {
+            match simulate_function(
+                &contract_id,
+                &source,
+                &network,
+                &function,
+                &func_args,
+                &retry_config,
+                args.quiet,
+            )? {
                 SimulationOutcome::Metrics {
                     instructions,
                     read_bytes,
@@ -1949,6 +2241,185 @@ mod tests {
         assert!(err.contains("tolerance must be a number"), "got: {err}");
     }
 
+    // --- Retry configuration -------------------------------------------------
+
+    #[test]
+    fn resolve_retry_config_precedence_cli_over_toml_over_default() {
+        let toml_retry = RetryToml {
+            max_attempts: Some(6),
+            initial_backoff_secs: Some(5),
+        };
+
+        // Defaults when neither source sets anything.
+        let config = resolve_retry_config(None, None, None).expect("defaults should resolve");
+        assert_eq!(config.max_attempts, MAX_DEPLOY_ATTEMPTS);
+        assert_eq!(
+            config.initial_backoff,
+            Duration::from_secs(INITIAL_RETRY_DELAY_SECS)
+        );
+        assert!(!config.disabled());
+
+        // budget.toml wins over defaults.
+        let config =
+            resolve_retry_config(None, None, Some(toml_retry)).expect("toml should resolve");
+        assert_eq!(config.max_attempts, 6);
+        assert_eq!(config.initial_backoff, Duration::from_secs(5));
+
+        // CLI wins over both.
+        let config = resolve_retry_config(Some(1), Some(7), Some(toml_retry))
+            .expect("cli should win over toml");
+        assert_eq!(config.max_attempts, 1);
+        assert_eq!(config.initial_backoff, Duration::from_secs(7));
+        assert!(config.disabled(), "max_attempts = 1 must disable retry");
+    }
+
+    #[test]
+    fn resolve_retry_config_partial_toml_section_keeps_defaults_for_missing_fields() {
+        let config = resolve_retry_config(
+            None,
+            None,
+            Some(RetryToml {
+                max_attempts: Some(2),
+                initial_backoff_secs: None,
+            }),
+        )
+        .expect("partial toml should resolve");
+        assert_eq!(config.max_attempts, 2);
+        assert_eq!(
+            config.initial_backoff,
+            Duration::from_secs(INITIAL_RETRY_DELAY_SECS)
+        );
+    }
+
+    #[test]
+    fn resolve_retry_config_rejects_zero_attempts() {
+        let err = resolve_retry_config(Some(0), None, None)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("max_attempts must be at least 1"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn is_transient_error_matches_plausibly_retryable_failures() {
+        for msg in [
+            "friendbot rate-limited (try again later)",
+            "HTTP 429 Too Many Requests",
+            "Connection refused",
+            "request timed out",
+            "connection reset by peer",
+            "service unavailable",
+        ] {
+            assert!(
+                is_transient_error(msg),
+                "{msg:?} should classify as transient"
+            );
+        }
+    }
+
+    #[test]
+    fn is_transient_error_treats_deterministic_failures_as_permanent() {
+        for msg in [
+            "contract CAMOCKCONTRACTID does not exist",
+            "Failed to decode XDR: invalid base64",
+            "simulation error: HostError",
+            "unknown argument --bogus",
+            "",
+        ] {
+            assert!(
+                !is_transient_error(msg),
+                "{msg:?} should classify as permanent"
+            );
+        }
+    }
+
+    #[test]
+    fn run_with_retry_max_attempts_one_makes_exactly_one_call() {
+        let config = RetryConfig {
+            max_attempts: 1,
+            initial_backoff: Duration::from_secs(0),
+        };
+        let calls = std::cell::Cell::new(0);
+        let result = run_with_retry(
+            &config,
+            true,
+            "test",
+            || {
+                calls.set(calls.get() + 1);
+                Err::<(), _>(RetryFailure::Transient("rate-limited".into()))
+            },
+            |last| Error::Message(format!("exhausted: {last}")),
+        );
+        assert!(result.is_err());
+        assert_eq!(calls.get(), 1, "retry disabled means exactly one attempt");
+    }
+
+    #[test]
+    fn run_with_retry_does_not_retry_permanent_failures() {
+        let config = RetryConfig {
+            max_attempts: 4,
+            initial_backoff: Duration::from_secs(0),
+        };
+        let calls = std::cell::Cell::new(0);
+        let result: Result<()> = run_with_retry(
+            &config,
+            true,
+            "test",
+            || {
+                calls.set(calls.get() + 1);
+                Err(RetryFailure::Permanent("contract does not exist".into()))
+            },
+            |last| Error::Message(format!("failed: {last}")),
+        );
+        assert!(result.is_err());
+        assert_eq!(calls.get(), 1, "permanent failures abort immediately");
+    }
+
+    #[test]
+    fn run_with_retry_reports_last_transient_error_on_exhaustion() {
+        let config = RetryConfig {
+            max_attempts: 3,
+            initial_backoff: Duration::from_secs(0),
+        };
+        let result: Result<()> = run_with_retry(
+            &config,
+            true,
+            "test",
+            || Err(RetryFailure::Transient("still rate-limited".into())),
+            |last| Error::Message(format!("exhausted: {last}")),
+        );
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("still rate-limited"), "got: {err}");
+    }
+
+    #[test]
+    fn run_with_retry_stops_as_soon_as_an_attempt_succeeds() {
+        let config = RetryConfig {
+            max_attempts: 4,
+            initial_backoff: Duration::from_secs(0),
+        };
+        let calls = std::cell::Cell::new(0);
+        let result: Result<&str> = run_with_retry(
+            &config,
+            true,
+            "test",
+            || {
+                let n = calls.get();
+                calls.set(n + 1);
+                if n < 2 {
+                    Err(RetryFailure::Transient("timed out".into()))
+                } else {
+                    Ok("ok")
+                }
+            },
+            |last| Error::Message(format!("exhausted: {last}")),
+        );
+        assert_eq!(result.expect("should succeed on third attempt"), "ok");
+        assert_eq!(calls.get(), 3);
+    }
+
     // --- Mode dispatch ------------------------------------------------------
 
     #[test]
@@ -1974,6 +2445,8 @@ mod tests {
             margin_read: None,
             margin_write: None,
             provenance_out: None,
+            max_retry_attempts: None,
+            retry_backoff_secs: None,
         };
         assert_eq!(Mode::from_args(&args), Mode::Report);
     }
@@ -2001,6 +2474,8 @@ mod tests {
             margin_read: None,
             margin_write: None,
             provenance_out: None,
+            max_retry_attempts: None,
+            retry_backoff_secs: None,
         };
         assert_eq!(
             Mode::from_args(&record),
@@ -2028,6 +2503,8 @@ mod tests {
             margin_read: None,
             margin_write: None,
             provenance_out: None,
+            max_retry_attempts: None,
+            retry_backoff_secs: None,
         };
         assert_eq!(
             Mode::from_args(&check),
@@ -2058,6 +2535,8 @@ mod tests {
             margin_read: None,
             margin_write: None,
             provenance_out: None,
+            max_retry_attempts: None,
+            retry_backoff_secs: None,
         };
         match Mode::from_args(&args) {
             Mode::Derive(out, _) => assert_eq!(out, PathBuf::from("tier-a-limits.env")),

--- a/cargo-budget-report/tests/fixtures/fake_bin/stellar
+++ b/cargo-budget-report/tests/fixtures/fake_bin/stellar
@@ -63,6 +63,27 @@ case "${1:-}" in
         esac
         ;;
       invoke)
+        # Optional invoke-failure simulation for retry tests.
+        # MOCK_STELLAR_INVOKE_FAIL_COUNT=N makes `contract invoke` fail the
+        # first N times; MOCK_STELLAR_INVOKE_FAIL_MODE selects the stderr
+        # text: "transient" (retryable) or "permanent" (not retryable).
+        INVOKE_FAIL_COUNT="${MOCK_STELLAR_INVOKE_FAIL_COUNT:-0}"
+        INVOKE_FAIL_MODE="${MOCK_STELLAR_INVOKE_FAIL_MODE:-transient}"
+        if [ "$INVOKE_FAIL_COUNT" -gt 0 ] && [ -n "$FAIL_COUNT_FILE" ]; then
+            if [ ! -f "$FAIL_COUNT_FILE" ]; then
+                echo "0" > "$FAIL_COUNT_FILE"
+            fi
+            call_num=$(cat "$FAIL_COUNT_FILE")
+            if [ "$call_num" -lt "$INVOKE_FAIL_COUNT" ]; then
+                echo "$((call_num + 1))" > "$FAIL_COUNT_FILE"
+                if [ "$INVOKE_FAIL_MODE" = "permanent" ]; then
+                    echo "Error: contract CAMOCKCONTRACTIDAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA does not exist" >&2
+                else
+                    echo "Error: connection reset by peer" >&2
+                fi
+                exit 1
+            fi
+        fi
         # Real output is a base64 XDR transaction envelope. Its content is
         # opaque to cargo-budget-report (it's forwarded verbatim to the RPC
         # `simulateTransaction` call), so any placeholder string is fine here

--- a/cargo-budget-report/tests/integration.rs
+++ b/cargo-budget-report/tests/integration.rs
@@ -277,3 +277,224 @@ fn retry_mechanism_fails_after_exhausting_all_attempts() {
         "stderr should mention source account funding, got: {stderr:?}"
     );
 }
+
+// ── Configurable retry policy integration tests ─────────────────────────
+
+/// `--max-retry-attempts 1` must disable retry entirely: a transient
+/// deploy failure fails the run on the first attempt with no backoff.
+#[test]
+fn max_retry_attempts_one_disables_retry_via_cli() {
+    let workspace = setup_mock_workspace();
+    let fail_count_file = workspace.path().join(".mock_stellar_fail_count_disabled");
+    let _ = fs::remove_file(&fail_count_file);
+
+    let output = budget_report_cmd(workspace.path())
+        .args([
+            "budget-report",
+            "--network",
+            "local",
+            "--source",
+            "alice",
+            "--max-retry-attempts",
+            "1",
+        ])
+        .env("MOCK_STELLAR_FAIL_COUNT", "3")
+        .env(
+            "MOCK_STELLAR_FAIL_COUNT_FILE",
+            fail_count_file.to_str().unwrap(),
+        )
+        .assert()
+        .failure()
+        .get_output()
+        .clone();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("Retrying in"),
+        "retry disabled must not print retry messages, got: {stderr:?}"
+    );
+    assert!(
+        stderr.contains("after 1 attempts"),
+        "should report exhaustion after exactly one attempt, got: {stderr:?}"
+    );
+}
+
+/// `[retry] max_attempts = 1` in budget.toml also disables retry.
+#[test]
+fn max_retry_attempts_one_disables_retry_via_budget_toml() {
+    let workspace = setup_mock_workspace();
+    fs::write(
+        workspace.path().join("budget.toml"),
+        "[retry]\nmax_attempts = 1\n",
+    )
+    .expect("failed to write budget.toml");
+    let fail_count_file = workspace.path().join(".mock_stellar_fail_count_toml_off");
+    let _ = fs::remove_file(&fail_count_file);
+
+    let output = budget_report_cmd(workspace.path())
+        .args(["budget-report", "--network", "local", "--source", "alice"])
+        .env("MOCK_STELLAR_FAIL_COUNT", "3")
+        .env(
+            "MOCK_STELLAR_FAIL_COUNT_FILE",
+            fail_count_file.to_str().unwrap(),
+        )
+        .assert()
+        .failure()
+        .get_output()
+        .clone();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("Retrying in"),
+        "retry disabled must not print retry messages, got: {stderr:?}"
+    );
+}
+
+/// budget.toml `[retry].max_attempts` is honored when no CLI flag is given:
+/// two configured attempts against three failures exhausts the budget.
+#[test]
+fn budget_toml_retry_max_attempts_is_respected() {
+    let workspace = setup_mock_workspace();
+    fs::write(
+        workspace.path().join("budget.toml"),
+        "[retry]\nmax_attempts = 2\ninitial_backoff_secs = 0\n",
+    )
+    .expect("failed to write budget.toml");
+    let fail_count_file = workspace.path().join(".mock_stellar_fail_count_toml_2");
+    let _ = fs::remove_file(&fail_count_file);
+
+    let output = budget_report_cmd(workspace.path())
+        .args(["budget-report", "--network", "local", "--source", "alice"])
+        .env("MOCK_STELLAR_FAIL_COUNT", "10")
+        .env(
+            "MOCK_STELLAR_FAIL_COUNT_FILE",
+            fail_count_file.to_str().unwrap(),
+        )
+        .assert()
+        .failure()
+        .get_output()
+        .clone();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("after 2 attempts"),
+        "budget.toml max_attempts = 2 should bound attempts, got: {stderr:?}"
+    );
+}
+
+/// The CLI flag overrides the budget.toml `[retry]` section: the config
+/// says retry is off, but `--max-retry-attempts 2` re-enables one retry,
+/// which is enough for the single transient failure.
+#[test]
+fn cli_max_retry_attempts_overrides_budget_toml() {
+    let workspace = setup_mock_workspace();
+    fs::write(
+        workspace.path().join("budget.toml"),
+        "[retry]\nmax_attempts = 1\n",
+    )
+    .expect("failed to write budget.toml");
+    let fail_count_file = workspace.path().join(".mock_stellar_fail_count_cli_wins");
+    let _ = fs::remove_file(&fail_count_file);
+
+    let output = budget_report_cmd(workspace.path())
+        .args([
+            "budget-report",
+            "--network",
+            "local",
+            "--source",
+            "alice",
+            "--max-retry-attempts",
+            "2",
+            "--retry-backoff-secs",
+            "0",
+        ])
+        .env("MOCK_STELLAR_FAIL_COUNT", "1")
+        .env(
+            "MOCK_STELLAR_FAIL_COUNT_FILE",
+            fail_count_file.to_str().unwrap(),
+        )
+        .assert()
+        .success()
+        .get_output()
+        .clone();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("WORKSPACE BUDGET REPORT"),
+        "CLI override should re-enable retry and succeed, got: {stdout}"
+    );
+}
+
+/// Retry applies to the invoke-build call site too: a transient
+/// (`connection reset by peer`) invoke failure is retried and the run
+/// still succeeds.
+#[test]
+fn transient_invoke_build_failure_is_retried_and_recovers() {
+    let workspace = setup_mock_workspace();
+    let fail_count_file = workspace.path().join(".mock_stellar_invoke_fail_transient");
+    let _ = fs::remove_file(&fail_count_file);
+
+    let output = budget_report_cmd(workspace.path())
+        .args([
+            "budget-report",
+            "--network",
+            "local",
+            "--source",
+            "alice",
+            "--retry-backoff-secs",
+            "0",
+        ])
+        .env("MOCK_STELLAR_INVOKE_FAIL_COUNT", "2")
+        .env(
+            "MOCK_STELLAR_FAIL_COUNT_FILE",
+            fail_count_file.to_str().unwrap(),
+        )
+        .assert()
+        .success()
+        .get_output()
+        .clone();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("WORKSPACE BUDGET REPORT"),
+        "report should succeed after transient invoke failures, got: {stdout}"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Invoke build attempt 1/4 failed"),
+        "stderr should show invoke-build retry progress, got: {stderr:?}"
+    );
+}
+
+/// A deterministic invoke failure (contract does not exist) must NOT be
+/// retried: the run fails on the first attempt with no retry messages.
+#[test]
+fn permanent_invoke_build_failure_is_not_retried() {
+    let workspace = setup_mock_workspace();
+    let fail_count_file = workspace.path().join(".mock_stellar_invoke_fail_permanent");
+    let _ = fs::remove_file(&fail_count_file);
+
+    let output = budget_report_cmd(workspace.path())
+        .args(["budget-report", "--network", "local", "--source", "alice"])
+        .env("MOCK_STELLAR_INVOKE_FAIL_COUNT", "5")
+        .env("MOCK_STELLAR_INVOKE_FAIL_MODE", "permanent")
+        .env(
+            "MOCK_STELLAR_FAIL_COUNT_FILE",
+            fail_count_file.to_str().unwrap(),
+        )
+        .assert()
+        .failure()
+        .get_output()
+        .clone();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("Retrying in"),
+        "permanent failures must not be retried, got: {stderr:?}"
+    );
+    assert!(
+        stderr.contains("does not exist"),
+        "the underlying deterministic error should surface, got: {stderr:?}"
+    );
+}

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -413,12 +413,40 @@ args = ["--n", "10000"]
 cpu_limit = 5000000
 read_limit = 5000
 write_limit = 1000
+
+# Retry policy for network calls (deploy, invoke-build, simulate RPC).
+[retry]
+# Total attempts including the first. `1` disables retry entirely.
+max_attempts = 4
+# Seconds to wait before the first retry; doubles on each further attempt.
+initial_backoff_secs = 2
 ```
 {% endcode %}
 
 - `network`, `source` — defaults for the corresponding CLI flags.
 - `[functions.<name>].args` — arguments injected when simulating that exported function. Functions without an entry are simulated with no arguments; if a required argument is missing, the simulation fails with a warning and that function is skipped.
 - `[functions.<name>].cpu_limit`, `.read_limit`, `.write_limit` — inclusive upper bounds for simulated CPU instructions, read bytes, and write bytes. Enforced only when `--check` is passed. A missing field means "not enforced" for that metric.
+
+### `[retry]`: transient-failure retry policy
+
+Deploy, invoke-build, and the simulate RPC request are all retried on *plausibly transient* failures: rate-limit responses (HTTP 429), connection errors and timeouts, and server-side blips (502/503). Deterministic failures — a contract that does not exist, a malformed XDR, an RPC-reported simulation error — are **not** retried, because repeating them cannot change the outcome.
+
+| Field | CLI override | Default | Meaning |
+|---|---|---|---|
+| `max_attempts` | `--max-retry-attempts` | `4` | Total attempts per call site, including the first. `1` disables retry. |
+| `initial_backoff_secs` | `--retry-backoff-secs` | `2` | Delay before the first retry; doubles on each subsequent attempt. |
+
+Precedence is CLI over `budget.toml` over defaults, matching every other configurable key.
+
+The worst-case time spent sleeping per call site is bounded and derivable from the config alone:
+
+```text
+initial_backoff_secs × (2^(max_attempts − 1) − 1)
+```
+
+With the defaults that is 2 + 4 + 8 = **14 s** per call site. A CI job with a tight time limit can set `max_attempts = 2` (worst case 2 s) or `max_attempts = 1` (no retry); against a private network that never rate-limits, `max_attempts = 1` removes the dead time entirely.
+
+Retry progress messages go to stderr and are suppressed by `--quiet`.
 
 ## Output
 


### PR DESCRIPTION
Closes #456

## Problem

`cargo budget-report` retried only deployments, with hardcoded constants: up to 4 attempts backing off 2 s → 4 s → 8 s (`MAX_DEPLOY_ATTEMPTS`, `INITIAL_RETRY_DELAY_SECS`). Two consequences:

1. **No way to turn retry down or off.** In CI, 14 s of backoff per flaky deploy across a multi-contract workspace can be the difference between a run that finishes and one that gets killed. Locally against a private network that never rate-limits, the retries are pure waste.
2. **Retry was applied at the wrong scope.** `simulate_transaction_rpc` and the invoke-XDR build had no retry at all — a single transient RPC failure mid-run failed the whole thing *after* the deploys had already succeeded, the most expensive possible moment to give up.

## What this PR does

### Shared retry helper

The existing deploy retry loop is extracted into one generic helper used by all three call sites instead of being copied three times:

- `run_with_retry(config, quiet, label, op, exhausted)` — main.rs
- Call sites: `deploy_contract_with_retry`, `build_invoke_xdr_with_retry`, `simulate_transaction_rpc_with_retry`

### Failure classification (retryable vs permanent)

Every attempt's error is classified as `RetryFailure::Transient` or `RetryFailure::Permanent`. Only transient failures consume attempts; a permanent failure aborts immediately, because repeating a deterministic failure four times just makes the run four times slower before it fails anyway.

**Classified as retryable** (plausibly fixed by waiting):

| Pattern | Why |
|---|---|
| `rate limit`, `rate-limited`, `ratelimit`, `429`, `too many requests` | Friendbot/RPC throttling is time-based; a backoff genuinely clears it |
| `connection`, `timed out`, `timeout`, `reset by peer`, `broken pipe` | Connection-level drops are network transients by definition |
| `503`, `502`, `unavailable`, `temporarily`, `try again` | Server-side blips that resolve on their own |
| non-zero `curl` exit / unparseable or empty RPC body | An empty/truncated body almost always means the connection dropped mid-response |

Classification is a conservative lowercase-substring whitelist (`is_transient_error`). Unknown errors are treated as permanent — failing fast on an unrecognized error beats burning 14 s of backoff hoping it goes away.

**Not retried** (deterministic): contract does not exist, malformed XDR/base64, RPC-reported simulation errors, rejected arguments, spawn failures of the `stellar`/`curl` binaries (environment problems no retry fixes).

### Configuration

| Key | Where | Default | Meaning |
|---|---|---|---|
| `max_attempts` | `[retry]` in budget.toml, `--max-retry-attempts` | `4` | Total attempts including the first. `1` disables retry. |
| `initial_backoff_secs` | `[retry]` in budget.toml, `--retry-backoff-secs` | `2` | Delay before first retry; doubles each subsequent attempt. |

- Precedence matches the rest of the tool: **CLI > budget.toml > default**.
- `max_attempts = 0` is rejected with an explicit error.
- Defaults unchanged, so existing setups behave identically.
- Worst-case sleep per call site is derivable from config alone: `initial_backoff × (2^(max_attempts − 1) − 1)` — 14 s at defaults.
- Retry messages still go to stderr and still respect `--quiet`.

## Demo runs (against the deterministic mock workspace)

### Retries disabled (`--max-retry-attempts 1`)

Fails on the first attempt, zero backoff:

```text
$ cargo budget-report --network local --source alice --max-retry-attempts 1   # MOCK_STELLAR_FAIL_COUNT=3
Checking Stellar CLI... found
Checking wasm32-unknown-unknown target... found
Retry is disabled (--max-retry-attempts 1): each call gets a single attempt.
Building package 'mock-contract-a' for wasm32...
Error: Failed to deploy mock-contract-a after 1 attempts. Ensure your source account is funded.
Last error: Error: friendbot rate-limited (try again later)
exit=1
```

### Configured down via budget.toml

```toml
[retry]
max_attempts = 2
initial_backoff_secs = 1
```

One transient deploy failure, one short retry, run completes:

```text
$ cargo budget-report --network local --source alice   # MOCK_STELLAR_FAIL_COUNT=1
Building package 'mock-contract-a' for wasm32...
Deploy attempt 1/2 failed. Retrying in 1 s...
Contract deployed at: CAMOCKCONTRACTIDAAAA...
...
=== WORKSPACE BUDGET REPORT ===
Summary: The values above are simulated resource amounts, not fees. ...
exit=0
```

## Test coverage

Unit tests (main.rs):
- `resolve_retry_config_precedence_cli_over_toml_over_default` and partial-section handling, following the existing `resolve_tolerance_precedence_*` pattern
- `resolve_retry_config_rejects_zero_attempts`
- `is_transient_error` classification tables for both directions
- `run_with_retry_max_attempts_one_makes_exactly_one_call` (the disabled path), `run_with_retry_does_not_retry_permanent_failures`, exhaustion reports last transient error, stop-on-first-success

Integration tests (tests/integration.rs) — existing `retry_mechanism_succeeds_after_transient_deploy_failures` / `..._fails_after_exhausting_all_attempts` unchanged and passing:
- disable via CLI flag and via `[retry] max_attempts = 1`
- budget.toml `max_attempts = 2` bounds attempts ("after 2 attempts")
- CLI overrides budget.toml
- transient invoke-build failure retried and recovered (`Invoke build attempt 1/4 failed`)
- permanent invoke-build failure not retried (no "Retrying in", underlying error surfaces)

The fake `stellar` fixture gained `MOCK_STELLAR_INVOKE_FAIL_COUNT` / `MOCK_STELLAR_INVOKE_FAIL_MODE` so the invoke-build call site can fail transiently (`connection reset by peer`) or permanently (`contract ... does not exist`) deterministically.

## Out of scope

Changing the defaults and adding jitter — both reasonable follow-ups, neither needed for configurability.

## Docs

`[retry]` documented in docs/src/reference.md alongside the other budget.toml sections, including the CLI flags, precedence, worst-case bound formula, and the classification policy.

## Verification

- `cargo test -p cargo-budget-report --bin`: 272 passed (the one failure, `derive::tests::scenario_limit_sums_components_with_margin`, fails identically on `main`)
- `cargo test -p cargo-budget-report --test integration`: 12/12 passed
- `cargo clippy -p cargo-budget-report --all-targets`: clean; `cargo fmt --check`: clean