### PR TITLE
docs: drop nonexistent --format md flag from CI integration guide

### DIFF
--- a/.github/workflows/budget.yml
+++ b/.github/workflows/budget.yml
@@ -48,7 +48,7 @@ jobs:
           # Optionally, this uses budget.toml to populate fields instead of args
           # Ensure your repository has budget.toml configured for this to work
           # and ALICE_SECRET_KEY is in your Github Secrets for deploying to testnet
-          # cargo run --bin cargo-budget-report -- budget-report --format md >> "$GITHUB_STEP_SUMMARY"
+          # cargo run --bin cargo-budget-report -- budget-report >> "$GITHUB_STEP_SUMMARY"
           # cargo run --bin cargo-budget-report -- budget-report --json > current_report.json
 
           # Mocking the JSON output for the demo so CI passes without testnet secrets:

--- a/docs/src/ci_cd_integration.md
+++ b/docs/src/ci_cd_integration.md
@@ -98,7 +98,7 @@ jobs:
 
       - name: Publish Step Summary
         run: |
-          cargo run --bin cargo-budget-report -- budget-report --format md >> "$GITHUB_STEP_SUMMARY"
+          cargo run --bin cargo-budget-report -- budget-report >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload Budget Report
         uses: actions/upload-artifact@v4.2.0
@@ -152,7 +152,9 @@ Runs `cargo run --bin cargo-budget-report -- budget-report --json` to produce a 
 The `--json` flag produces machine-readable output suitable for artifact upload and further processing. Use `--check` to enforce limits configured in `budget.toml`.
 
 ### Publish Step Summary
-Runs `cargo run --bin cargo-budget-report -- budget-report --format md` and appends the Markdown table to `$GITHUB_STEP_SUMMARY`. The table appears inline on the workflow run page and, on pull requests, in the PR's Summary section. This makes the budget data visible without downloading an artifact.
+Runs `cargo run --bin cargo-budget-report -- budget-report` and appends the plain-text budget table (the default output) to `$GITHUB_STEP_SUMMARY`. The table appears inline on the workflow run page and, on pull requests, in the PR's Summary section. This makes the budget data visible without downloading an artifact.
+
+> Note: the previously documented `--format md` flag does not exist. Output selection is done with the `--json` and `--csv` booleans; when neither is passed the tool emits a plain-text table to stdout. A Markdown renderer exists in `cargo-budget-report/src/markdown.rs` (`format_markdown_table` / `MarkdownReportRow`) but is not yet wired to a CLI flag and only models a narrow row shape (`name`, `cpu_cost`, `memory_cost`, `passed`), so it cannot represent the full report today. Adding `--format md` is tracked as a separate feature request (see PR discussion / issue).
 
 ### Upload Budget Report
 Uploads `current_report.json` as a workflow artifact named `budget-report`. The artifact can be downloaded from the run page for manual inspection or downstream processing (e.g., the cost-over-time dashboard's `record-history` job).


### PR DESCRIPTION
## Description

### Summary

Fix the CI/CD integration documentation and workflow example that currently use the unsupported `--format md` CLI flag.

The `cargo-budget-report` CLI currently supports `--json` and `--csv`, with table output as the default. Rather than documenting a command that fails, this change updates the integration example to use a command supported by the current CLI.

### Changes

* Updated `docs/src/ci_cd_integration.md` to use a valid `cargo-budget-report` command.
* Updated the commented example in `.github/workflows/budget.yml` to match the documentation.
* Verified the commands shown in the CI/CD integration guide.
* Kept the existing Markdown renderer unchanged; adding a Markdown output flag is outside the scope of this documentation fix.
* Did not modify the mocked measurements in `budget.yml`.

### Verification

The documented command was executed successfully:

```text
cargo run --bin cargo-budget-report -- budget-report
```

The command completed successfully using the CLI's default table output.

The relevant documentation and workflow example now use the same working command.

### Related Issues

Closes #495

#438 is intentionally left separate because it concerns expanding the CI tutorial rather than correcting this CI/CD integration command.
