### PR TITLE
docs: remove phantom .budget-cache.toml from reset instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@ target/
 venv/
 .venv/
 contract_id.txt
-.budget-cache.toml
 req.json
 node_modules/
 /dist

--- a/docs/src/developer_guide.md
+++ b/docs/src/developer_guide.md
@@ -260,16 +260,19 @@ network = "testnet"
 source = "bob"  # changed from "alice"
 ```
 
-**Reset the local environment** (use when cache or configuration is stale):
+**Reset the local environment** (use when a stale WASM build produces confusing numbers):
+
+`cargo budget-report` keeps no cache of its own — every run rebuilds the WASM and deploys it from scratch, so there are no cached deploy artifacts to remove. The only stale state that can affect results is the Cargo build output in `target/`, which Cargo normally rebuilds incrementally and correctly. If you want a guaranteed-clean run anyway:
 
 ```bash
-# Remove the cached deploy artifacts
-rm -f .budget-cache.toml
+# Force a from-scratch WASM build (removes all build output)
+cargo clean
 
 # Rebuild and re-deploy
-cargo build -p amm-pool-contract --release --target wasm32-unknown-unknown
 cargo budget-report
 ```
+
+A full `cargo clean` also wipes host-side debug builds, so prefer `rm -rf target/wasm32-unknown-unknown` if you only want to invalidate the WASM artifacts. Note that each `cargo budget-report` run deploys a *new* contract instance on the target network; previously deployed contract IDs are not tracked or reused, so there is nothing to reset on that side.
 
 ### Best practices
 


### PR DESCRIPTION
Closes #457

## Summary

`docs/src/developer_guide.md`'s "Reset the local environment" section told readers to run `rm -f .budget-cache.toml` to clear "cached deploy artifacts". No such file exists: nothing in the repo writes it, reads it, or documents it. Because `rm -f` succeeds silently on a missing file, readers following the reset procedure believed they had cleared a cache that was never there.

This PR removes the phantom step and replaces it with an accurate description of what is actually stateful locally.

## What I verified is actually stateful

- **No deploy cache exists.** `cargo-budget-report` keeps no cache of its own. Every run rebuilds the WASM (`deploy_and_measure`, main.rs:1416–1427) and deploys from scratch via `stellar contract deploy` (`deploy_contract_with_retry`, main.rs:1074). Deployed contract IDs are never persisted between runs, so there is nothing to reset on the deploy side.
- **`.budget-cache.toml` appeared exactly twice** in the repo before this change: the guide's `rm -f` command, and a stale entry in `.gitignore` (the issue text said it wasn't in `.gitignore`, but it was — line 5). Both are removed; `grep -rn 'budget-cache' .` now returns zero hits.
- **The only local state that can affect results is the Cargo build output under `target/`.** The section now says this explicitly and offers `cargo clean` (full) or `rm -rf target/wasm32-unknown-unknown` (WASM-only) for a guaranteed-clean rebuild.
- **Dropped the redundant explicit `cargo build -p amm-pool-contract ...` line** — `cargo budget-report` builds every cdylib package itself, so the separate build step in the old snippet did nothing the report run wouldn't do.
- **Checked for siblings:** no other page in `docs/src/` refers to a deploy cache. The only remaining "cache" mentions are the unrelated CI `Swatinem/rust-cache` dependency cache in `ci_cd_integration.md`.


## Testing

Docs-only change (`docs/src/developer_guide.md` + one `.gitignore` line); no Rust code touched. `grep -rn 'budget-cache' .` confirms zero remaining references. Note: `cargo fmt/clippy/test` could not be executed in the authoring environment (no toolchain installed), but no code paths were modified.