### PR TITLE
ci: pin third-party actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/budget.yml
+++ b/.github/workflows/budget.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           toolchain: 1.93.0
           targets: wasm32v1-none wasm32-unknown-unknown
@@ -68,7 +68,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload Budget Report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: budget-report
           path: current_report.json
@@ -84,12 +84,12 @@ jobs:
       contents: write
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       with:
         fetch-depth: 0
 
     - name: Download Budget Report
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         name: budget-report
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,20 +13,20 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
           components: rustfmt, clippy, llvm-tools
 
       - name: Rust Cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
           key: coverage
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@b6ff580856c41316412a0b9b60540fbc6f8c82cc # v2
         with:
           tool: cargo-llvm-cov
 
@@ -67,7 +67,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload Coverage Report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coverage-report
           path: lcov.info

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Build static site
         run: |
@@ -39,7 +39,7 @@ jobs:
           # its build output directory instead of `dist/`.
 
       - name: Deploy to GitHub Pages (preserve history.json)
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -13,15 +13,15 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
           components: rustfmt, clippy
 
       - name: Rust Cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
 
       - name: Install System Dependencies
         run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config libudev-dev

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,10 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 
       - name: Dry run budget-macros
         run: cargo publish -p budget-macros --dry-run
@@ -53,10 +53,10 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           target: ${{ matrix.target }}
 
@@ -72,7 +72,7 @@ jobs:
         run: cp target/${{ matrix.target }}/release/${{ matrix.bin }} ${{ matrix.name }}
 
       - name: Upload Build Artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ${{ matrix.name }}
           path: ${{ matrix.name }}
@@ -83,9 +83,9 @@ jobs:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: cargo-budget-report-*
           merge-multiple: true
@@ -94,7 +94,7 @@ jobs:
         run: sha256sum cargo-budget-report-* > SHA256SUMS
 
       - name: Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
           files: |
             cargo-budget-report-*
@@ -106,10 +106,10 @@ jobs:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 
       - name: Verify tag version matches crate versions
         run: |


### PR DESCRIPTION
Closes #461

## What

Every `uses:` reference to an action outside the Tollcraft organisation is now pinned to a **full-length commit SHA**, each carrying a trailing comment with the human-readable version it was resolved from (`# v4`), so the files stay readable and Dependabot can still parse and bump them. Per GitHub's own Actions hardening guidance: tags are mutable, whoever controls a tag controls what runs in CI — and two of these workflows (`budget.yml` → `record-history`, `deploy-site.yml`) hold `contents: write` and touch `gh-pages`/releases.

This matches the convention already used in the org — `soroban-cost-coster-linter`'s publish workflow pins `dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9`.

**Out of scope (unchanged):** no action version changed, no action replaced, no workflow permissions altered.

## Tag → SHA resolution table

Every SHA was resolved from the exact ref the workflow referenced at the time of this PR (via `gh api repos/<owner>/<repo>/git/ref/tags/<tag>`, dereferenced through `/git/tags/<sha>` for the three annotated tags), so this change alters provenance only, not behaviour:

| Action | Resolved from | Full-length SHA | Call sites |
|---|---|---|---|
| `actions/checkout` | tag `v7` | `3d3c42e5aac5ba805825da76410c181273ba90b1` | budget ×2, coverage, deploy-site, quality, release ×4 |
| `actions/upload-artifact` | tag `v7` | `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` | budget, coverage, release |
| `actions/download-artifact` | tag `v8` | `3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c` | budget, release |
| `dtolnay/rust-toolchain` | branch `stable` @ `4360b52` ("toolchain: stable", 2026-08-05) | `4360b52568e2003a75bf9bc1d59f33a8e3fc893c` | budget, release ×3 |
| `actions-rust-lang/setup-rust-toolchain` | tag `v1` | `166cdcfd11aee3cb47222f9ddb555ce30ddb9659` | coverage, quality |
| `Swatinem/rust-cache` | tag `v2` | `6323deb102c322ba6fcbdcafc7e3dddab59af2b6` | coverage, quality |
| `taiki-e/install-action` | tag `v2` | `b6ff580856c41316412a0b9b60540fbc6f8c82cc` | coverage |
| `peaceiris/actions-gh-pages` | tag `v4` | `84c30a85c19949d7eee79c4ff27748b70285e453` | deploy-site |
| `softprops/action-gh-release` | tag `v3` | `3d0d9888cb7fd7b750713d6e236d1fcb99157228` | release |

All nine refs are third-party to Tollcraft; no first-party actions exist in the repo. Total: 25 `uses:` lines pinned across all five workflows.

## The four `dtolnay/rust-toolchain@stable` call sites, resolved deliberately

Pinning a SHA freezes the *action's code*; the toolchain it installs is decided by its inputs at runtime. Each of the four sites was checked individually — behaviour is unchanged in every case:

| Call site | Inputs | What it installs before | What it installs after pinning |
|---|---|---|---|
| `budget.yml` → `budget-check` "Install Rust" | `toolchain: 1.93.0`, `targets: wasm32v1-none wasm32-unknown-unknown` | Exactly `1.93.0` (explicit input overrides the branch) | Identical — still exactly `1.93.0`. The branch position never mattered here. |
| `release.yml` → `publish-dry-run` "Install Rust" | none | Latest stable channel, resolved at runtime | Identical — no `toolchain` input means the action still defaults to the stable channel resolved at run time; only the action's code is frozen. |
| `release.yml` → `build` matrix "Install Rust" | `target: ${{ matrix.target }}` | Latest stable + the matrix target | Identical — same default-to-stable behaviour plus the unchanged `target` input. |
| `release.yml` → `publish` "Install Rust" | none | Latest stable channel, resolved at runtime | Identical — same as publish-dry-run. |

So for the three release-workflow sites, "stable" remains a runtime channel decision made by the (now immutable) action code; freezing the SHA does not freeze the toolchain. If the maintainers ever want the toolchain frozen too, that is an explicit follow-up (set `toolchain:` inputs) and deliberately not done here since it would change behaviour.

## Dependabot keeps working

`.github/dependabot.yml` already has the `github-actions` ecosystem on a weekly schedule with grouped updates (`actions` group, pattern `*`). Dependabot supports exactly this form — `uses: owner/repo@<full-sha> # vX.Y.Z` — and its weekly PRs will bump both the SHA and refresh the trailing comment. Nothing needed changing in `.github/dependabot.yml`: the pinned-with-comment style is the one it parses and updates, not one it silently skips. The first weekly run after merge should propose SHAs if any of these repos publish new releases.

## Verification (ran, not read)

- [x] All five workflows re-validated as YAML after editing.
- [x] Grep over `.github/workflows/` confirms zero remaining mutable refs (`@v*`, `@stable`) — every `uses:` is a 40-hex SHA.
- [x] `Soroban Budget Check` (budget.yml) ran green on this branch.
- [x] `Coverage` (coverage.yml) ran green on this branch.
- [x] `Code Quality` (quality.yml) ran green on this branch.
- [x] `Release` dry-run job (release.yml `publish-dry-run`, which runs on `pull_request`) ran green on this branch.
- [x] `Deploy Site to GitHub Pages` (deploy-site.yml) triggered via `workflow_dispatch` on this branch and ran green.
- Release tag-path jobs (`build`, `checksums`, `Release`, `publish`) fire only on `v*` tags; they use the identical pinned SHAs already exercised above (`checkout`, `upload-artifact`, `download-artifact`, `rust-toolchain`, `action-gh-release`). A real pre-release tag test would invoke `cargo publish` against crates.io with `CARGO_REGISTRY_TOKEN`, which forks don't hold, so it was not executed from this fork; recommend the tag-path smoke test on the next routine release, or on a fork-side pre-release tag if a throwaway registry token is available.

## Notes for reviewers

- The three annotated tags dereferenced (`Swatinem/rust-cache@v2`, `peaceiris/actions-gh-pages@v4`, `softprops/action-gh-release@v3`) pointed at tag *objects*; the table lists the underlying commit SHAs, which is what GitHub Actions executes.
- `dtolnay/rust-toolchain@stable` deserves the emphasis the issue gives it: it is a branch that moves by design. It now points at the commit `4360b52568e2003a75bf9bc1d59f33a8e3fc893c`; Dependabot will track upstream movements of `stable` and bump the pin weekly like any other action update.
