### PR TITLE
fix: wire orphaned additional_edge_tests module and repair drifted tests

### DIFF
--- a/cargo-budget-report/src/additional_edge_tests.rs
+++ b/cargo-budget-report/src/additional_edge_tests.rs
@@ -51,6 +51,7 @@ mod off_by_one_and_zero_length_tests {
             cpu_limit: Some(5_000_000),
             read_limit: Some(1_000),
             write_limit: Some(500),
+            tolerance: None,
         };
         // "Bytes" (exact match, no prefix) does not match any known metric.
         assert_eq!(limit_for_metric(&config, "Bytes"), None);
@@ -70,6 +71,7 @@ mod off_by_one_and_zero_length_tests {
             cpu_limit: Some(5_000_000),
             read_limit: None,
             write_limit: None,
+            tolerance: None,
         };
         assert_eq!(limit_for_metric(&config, "CPU Instructions\n"), None);
     }

--- a/cargo-budget-report/src/main.rs
+++ b/cargo-budget-report/src/main.rs
@@ -1735,6 +1735,9 @@ mod edge_case_tests;
 #[cfg(test)]
 mod boundary_tests;
 
+#[cfg(test)]
+mod additional_edge_tests;
+
 /// Serializes tests that mutate the process working directory.
 #[cfg(test)]
 static TEST_CWD_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());


### PR DESCRIPTION
## Problem

`main`'s **Code Quality / lint** check is currently red at `5be7f08a`:

```
orphaned: ./cargo-budget-report/src/additional_edge_tests.rs is not reachable from any crate root (missing `mod` declaration)
```

PR #530 ("give the numbered modules meaningful names") added `additional_edge_tests.rs` but never declared it in the module tree. The file has sat outside the crate since then — never compiled, never linted, never tested. The module-reachability check landed by #519 now catches it, which is exactly what that check is for.

## Fix

1. **Declare the module** — add `#[cfg(test)] mod additional_edge_tests;` to `main.rs`, right next to the sibling `edge_case_tests` and `boundary_tests` modules it was renamed alongside.
2. **Repair what drifted while it was orphaned** — the file had never been compiled since `FunctionConfig` gained its `tolerance` field, so the two struct initializers were missing it. Added `tolerance: None` to both, matching the `#[serde(default)]` pattern.

The file's 43 tests now compile, lint, and run for the first time since the rename.

## Verification

- `scripts/check-module-reachability.sh` — pass (all `.rs` files under `src/` reachable)
- `cargo fmt --all -- --check` — pass
- `cargo clippy --workspace --all-targets -- -D warnings` — pass
- `cargo test --workspace` — all pass; `cargo-budget-report` unit tests go from 282 → 325 now that the module's tests actually run
- `cargo machete` — pass

This turns `main`'s lint back green.
