### PR TITLE
feat: add --record/--replay CLI flags for the transport layer (#451 #452)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -961,6 +961,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "host-function-contract"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/cargo-budget-report/src/additional_edge_tests.rs
+++ b/cargo-budget-report/src/additional_edge_tests.rs
@@ -51,6 +51,7 @@ mod off_by_one_and_zero_length_tests {
             cpu_limit: Some(5_000_000),
             read_limit: Some(1_000),
             write_limit: Some(500),
+            tolerance: None,
         };
         // "Bytes" (exact match, no prefix) does not match any known metric.
         assert_eq!(limit_for_metric(&config, "Bytes"), None);
@@ -70,6 +71,7 @@ mod off_by_one_and_zero_length_tests {
             cpu_limit: Some(5_000_000),
             read_limit: None,
             write_limit: None,
+            tolerance: None,
         };
         assert_eq!(limit_for_metric(&config, "CPU Instructions\n"), None);
     }

--- a/cargo-budget-report/src/cli.rs
+++ b/cargo-budget-report/src/cli.rs
@@ -165,4 +165,21 @@ pub struct BudgetReportArgs {
     /// `--check` mode rows also show their limit and pass/fail status.
     #[arg(long, default_value_t = false)]
     pub html: bool,
+
+    /// Record every transport response (deploy, invoke-build, and
+    /// simulate RPC) into a replayable fixture file at this path.
+    ///
+    /// The run itself still talks to the network; the fixture it writes
+    /// lets a later `--replay` run reproduce the same report offline.
+    #[arg(long, value_name = "PATH", conflicts_with = "replay")]
+    pub record: Option<String>,
+
+    /// Replay a run from a fixture file written by `--record`.
+    ///
+    /// The whole report pipeline runs offline: no `stellar` CLI, no
+    /// `curl`, no network access. Deploy, invoke-build and simulate RPC
+    /// responses are served from the fixture. `--record` and `--replay`
+    /// are mutually exclusive.
+    #[arg(long, value_name = "PATH", conflicts_with = "record")]
+    pub replay: Option<String>,
 }

--- a/cargo-budget-report/src/main.rs
+++ b/cargo-budget-report/src/main.rs
@@ -1175,6 +1175,72 @@ fn is_leap(y: u64) -> bool {
     (y.is_multiple_of(4) && !y.is_multiple_of(100)) || y.is_multiple_of(400)
 }
 
+/// The transport a run uses, chosen by CLI flags.
+///
+/// `--replay <path>` serves every deploy/invoke/simulate response from a
+/// recorded fixture, so the whole pipeline runs with no `stellar` CLI,
+/// `curl`, or network access. `--record <path>` wraps the live transport
+/// and captures every response so a later run can be replayed. Without
+/// either flag, runs use [`live::LiveTransport`] directly.
+enum TransportKind {
+    Live(live::LiveTransport),
+    Recording(record::RecordingTransport<live::LiveTransport>),
+    Replay(replay::ReplayTransport),
+}
+
+impl transport::Transport for TransportKind {
+    fn deploy_contract(
+        &mut self,
+        wasm_path: &Path,
+        source: &str,
+        network: &str,
+        package_name: &str,
+    ) -> anyhow::Result<String> {
+        match self {
+            TransportKind::Live(t) => t.deploy_contract(wasm_path, source, network, package_name),
+            TransportKind::Recording(t) => {
+                t.deploy_contract(wasm_path, source, network, package_name)
+            }
+            TransportKind::Replay(t) => t.deploy_contract(wasm_path, source, network, package_name),
+        }
+    }
+
+    fn build_invoke_xdr(
+        &mut self,
+        contract_id: &str,
+        source: &str,
+        network: &str,
+        function: &str,
+        func_args: &[String],
+        package: &str,
+    ) -> anyhow::Result<String> {
+        match self {
+            TransportKind::Live(t) => {
+                t.build_invoke_xdr(contract_id, source, network, function, func_args, package)
+            }
+            TransportKind::Recording(t) => {
+                t.build_invoke_xdr(contract_id, source, network, function, func_args, package)
+            }
+            TransportKind::Replay(t) => {
+                t.build_invoke_xdr(contract_id, source, network, function, func_args, package)
+            }
+        }
+    }
+
+    fn simulate_transaction(
+        &mut self,
+        b64_xdr: &str,
+        package: &str,
+        function: &str,
+    ) -> anyhow::Result<serde_json::Value> {
+        match self {
+            TransportKind::Live(t) => t.simulate_transaction(b64_xdr, package, function),
+            TransportKind::Recording(t) => t.simulate_transaction(b64_xdr, package, function),
+            TransportKind::Replay(t) => t.simulate_transaction(b64_xdr, package, function),
+        }
+    }
+}
+
 fn main() -> anyhow::Result<()> {
     let CargoCli::BudgetReport(args) = CargoCli::parse();
 
@@ -1196,7 +1262,11 @@ fn main() -> anyhow::Result<()> {
     }
 
     // ── Preflight environment checks ──────────────────────────────────
-    run_preflight_checks(args.quiet)?;
+    // Replay runs serve every network call from a fixture, so they need
+    // neither the `stellar` CLI nor `curl`; skip the checks entirely.
+    if args.replay.is_none() {
+        run_preflight_checks(args.quiet)?;
+    }
 
     let toml_config = load_budget_toml("budget.toml")?;
     let default_tolerance = resolve_tolerance(args.tolerance.as_deref(), &toml_config)
@@ -1243,10 +1313,22 @@ fn main() -> anyhow::Result<()> {
     let build_profile = args.profile.as_deref().unwrap_or("release");
 
     // All network interaction happens through the transport. Production runs
-    // use `LiveTransport` (which owns the retry policy); `ReplayTransport`
-    // (fed by `RecordingTransport`) is available to tests and a follow-up
-    // CLI flag.
-    let mut transport = live::LiveTransport::new(retry_config, args.quiet);
+    // use `LiveTransport` (which owns the retry policy); `--record` wraps it
+    // in a `RecordingTransport` that captures every response, and `--replay`
+    // serves responses back from a recorded fixture with no network at all.
+    let mut transport = if let Some(replay_path) = &args.replay {
+        TransportKind::Replay(replay::ReplayTransport::new(
+            fixture::FixtureFile::load(replay_path)
+                .with_context(|| format!("failed to load replay fixture {}", replay_path))?,
+        ))
+    } else if args.record.is_some() {
+        TransportKind::Recording(record::RecordingTransport::new(live::LiveTransport::new(
+            retry_config,
+            args.quiet,
+        )))
+    } else {
+        TransportKind::Live(live::LiveTransport::new(retry_config, args.quiet))
+    };
 
     for package in metadata.packages {
         let is_cdylib = package
@@ -1429,7 +1511,9 @@ fn main() -> anyhow::Result<()> {
                     }
 
                     // ── Optional Stellar CLI validation ──────────────
-                    if args.validate {
+                    // `--validate` shells out to `stellar xdr decode`, which
+                    // replay mode cannot assume exists; skip it there.
+                    if args.validate && args.replay.is_none() {
                         let v_result = validate::validate_metrics(
                             &transaction_data_xdr,
                             instructions,
@@ -1499,6 +1583,23 @@ fn main() -> anyhow::Result<()> {
                     }
                 }
             }
+        }
+    }
+
+    // Persist the recorded fixture when `--record` was requested, so the
+    // run can be reproduced offline with `--replay`.
+    if let Some(path) = &args.record {
+        match transport {
+            TransportKind::Recording(recording) => {
+                recording
+                    .into_fixture()
+                    .save(path)
+                    .with_context(|| format!("failed to save fixture to {}", path))?;
+                if !args.quiet {
+                    eprintln!("Recorded fixture to {}", path);
+                }
+            }
+            _ => unreachable!("--record always constructs a RecordingTransport"),
         }
     }
 
@@ -2292,6 +2393,8 @@ mod tests {
             tolerance: None,
             quiet: false,
             validate: false,
+            record: None,
+            replay: None,
             profile: None,
             derive_limits: None,
             from: None,
@@ -2322,6 +2425,8 @@ mod tests {
             tolerance: None,
             quiet: false,
             validate: false,
+            record: None,
+            replay: None,
             profile: None,
             derive_limits: None,
             from: None,
@@ -2352,6 +2457,8 @@ mod tests {
             tolerance: None,
             quiet: false,
             validate: false,
+            record: None,
+            replay: None,
             profile: None,
             derive_limits: None,
             from: None,
@@ -2385,6 +2492,8 @@ mod tests {
             tolerance: None,
             quiet: false,
             validate: false,
+            record: None,
+            replay: None,
             profile: None,
             derive_limits: Some("tier-a-limits.env".to_string()),
             from: None,

--- a/cargo-budget-report/src/main.rs
+++ b/cargo-budget-report/src/main.rs
@@ -1735,6 +1735,9 @@ mod edge_case_tests;
 #[cfg(test)]
 mod boundary_tests;
 
+#[cfg(test)]
+mod additional_edge_tests;
+
 /// Serializes tests that mutate the process working directory.
 #[cfg(test)]
 static TEST_CWD_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());

--- a/cargo-budget-report/tests/integration.rs
+++ b/cargo-budget-report/tests/integration.rs
@@ -573,3 +573,79 @@ fn permanent_invoke_build_failure_is_not_retried() {
         "the underlying deterministic error should surface, got: {stderr:?}"
     );
 }
+
+// ── Record / replay transport integration tests ─────────────────────────
+
+#[test]
+fn record_then_replay_produces_identical_report() {
+    let workspace = setup_mock_workspace();
+    let fixture_path = workspace.path().join("fixture.json");
+
+    // First run records every transport response into the fixture. It runs
+    // against the fake stellar/curl scripts like the other tests.
+    let record = budget_report_cmd(workspace.path())
+        .args([
+            "budget-report",
+            "--network",
+            "local",
+            "--source",
+            "alice",
+            "--record",
+            fixture_path.to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .clone();
+    let recorded_stdout = String::from_utf8_lossy(&record.stdout);
+    assert!(
+        recorded_stdout.contains("WORKSPACE BUDGET REPORT"),
+        "recorded run should produce a report, got: {recorded_stdout}"
+    );
+
+    // The fixture must exist and contain the expected entry keys.
+    let fixture: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&fixture_path).expect("fixture should be written"))
+            .expect("fixture should be valid JSON");
+    assert_eq!(fixture["fixture_version"], 1);
+    let entries = fixture["entries"]
+        .as_object()
+        .expect("fixture should have an entries object");
+    assert!(
+        entries.keys().any(|k| k.starts_with("deploy:")),
+        "fixture should contain deploy entries, got keys: {:?}",
+        entries.keys()
+    );
+    assert!(
+        entries.keys().any(|k| k.starts_with("simulate:")),
+        "fixture should contain simulate entries, got keys: {:?}",
+        entries.keys()
+    );
+
+    // Replay with a PATH that excludes the fake stellar/curl scripts: the
+    // whole pipeline must run with no `stellar` CLI and no `curl` at all.
+    let mut replay_cmd = Command::cargo_bin("cargo-budget-report").expect("binary should be built");
+    replay_cmd
+        .current_dir(workspace.path())
+        .env("PATH", std::env::var("PATH").unwrap_or_default());
+    let replay = replay_cmd
+        .args([
+            "budget-report",
+            "--network",
+            "local",
+            "--source",
+            "alice",
+            "--replay",
+            fixture_path.to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .clone();
+    let replayed_stdout = String::from_utf8_lossy(&replay.stdout);
+
+    assert_eq!(
+        recorded_stdout, replayed_stdout,
+        "replaying the fixture must reproduce the recorded report byte-for-byte"
+    );
+}

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -336,10 +336,12 @@ cargo budget-report [--network <network>] [--source <source>] [--json] [--check]
 | `--json` | no | Emit the report as pretty-printed JSON instead of a table |
 | `--html` | no | Emit the report as a single self-contained HTML page — no external CSS, scripts, or fonts, so it renders from a `file://` URL and from a downloaded CI artifact. Rows mirror the JSON output; with `--check` each row also shows its limit and pass/fail status |
 | `--check` | no | Compare measured metrics against `cpu_limit` / `read_limit` / `write_limit` declared per function in `budget.toml`; print a per-function+metric pass/fail line and exit non-zero on any breach or failed configured simulation |
+| `--record <PATH>` | no | Record every transport response (deploy, invoke-build, simulate RPC) into a replayable fixture file at `PATH`. The run itself still talks to the network; the fixture lets a later `--replay` reproduce the same report offline. Mutually exclusive with `--replay` |
+| `--replay <PATH>` | no | Replay a run from a fixture written by `--record`. The whole pipeline runs offline — no `stellar` CLI, no `curl`, no network access — and the report is byte-identical to the recorded run. Mutually exclusive with `--record` |
 
 Configuration precedence: a CLI flag overrides the `budget.toml` value. If neither provides `network`/`source`, the command exits with an error naming the missing field.
 
-External requirements: the `stellar` CLI on `PATH`, a funded source identity on the target network, and the `wasm32-unknown-unknown` Rust target installed.
+External requirements: the `stellar` CLI on `PATH`, a funded source identity on the target network, and the `wasm32-unknown-unknown` Rust target installed. `--replay` is the exception — it needs none of the network tooling (no `stellar`, no `curl`), only the workspace itself.
 
 ### Required release profile for comparable measurements
 


### PR DESCRIPTION
## Summary

This PR promotes the record/replay transport layer — built and unit-tested as part of **#451** but deliberately left without a user-facing switch — to a real CLI feature: `--record <PATH>` and `--replay <PATH>`.

`cargo budget-report --record fixture.json` runs normally against the network and writes every transport response (deploy, invoke-build, simulate RPC) into a replayable fixture. `cargo budget-report --replay fixture.json` then reproduces the same report **byte-for-byte with no `stellar` CLI, no `curl`, and no network access** — the preflight checks and `--validate` (which shells out to `stellar xdr decode`) are skipped in replay mode.

## What changed

- **`cli.rs`** — two new mutually exclusive flags: `--record <PATH>` and `--replay <PATH>` (clap `conflicts_with`).
- **`main.rs`** — a `TransportKind` enum (Live / Recording / Replay) delegates the `Transport` trait; transport selection happens once at startup; the preflight checks are skipped when replaying; the fixture is persisted after the run when recording.
- **`tests/integration.rs`** — a round-trip test records a run against the fake `stellar`/`curl` scripts, verifies the fixture's entry keys, then replays with a `PATH` that contains **neither** fake binary and asserts the report is identical.
- **`docs/src/reference.md`** — the two flags and the replay mode's offline guarantee.

## Verification

- `cargo fmt --all -- --check` — pass
- `cargo clippy --workspace --all-targets -- -D warnings` — pass
- `scripts/check-module-reachability.sh` — pass
- `cargo machete` — pass
- `cargo test --workspace` — 468 passed, 0 failed (includes the new record→replay round-trip integration test)
- `cargo publish -p budget-macros --dry-run` / `cargo publish -p cargo-budget-report --dry-run` — pass

## Notes

- This is the follow-up #451 explicitly called out: *"Adding a CLI flag for record/replay is out of scope — wire the layer, leave the user-facing switch to a follow-up."* The core wiring (transport trait, record/replay/fixture modules, reachability CI check) landed via #519; this PR adds the switch.
- The branch also carries the `additional_edge_tests.rs` module wiring fix, because `main`'s Code Quality CI is currently red on that orphan (see #538) and this PR's CI runs against the merge ref. If both are open, this one supersedes #538.

Closes #451
Closes #452
