### PR TITLE
docs: align README SDK support table with actual manifest pins

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,17 +65,27 @@ Example: `https://your-org.github.io/your-repo/dashboard.html?limit=100`.
 
 ## ⚙️ Supported Versions & Compatibility
 
-* **Supported SDK Version**: `soroban-sdk` = `"22.0.11"` (specifically tested/resolved to `22.0.11` in `Cargo.lock`)
-* **Supported XDR Version**: `stellar-xdr` = `"22.1.0"` (used for decoding transaction simulation responses)
+The workspace does not pin a single `soroban-sdk` version — the two contract fixtures pin different ones, and the reporting CLI depends on the XDR decoder rather than the SDK. The manifest dependencies (the source of truth for intent; `Cargo.lock` only records resolution) are:
+
+| Crate | Manifest dependency |
+| :--- | :--- |
+| `amm-pool-contract` ([manifest](amm-pool-contract/Cargo.toml)) | `soroban-sdk` = `"22.0.11"` (also as a dev-dependency with the `testutils` feature) |
+| `host-function-contract` ([manifest](host-function-contract/Cargo.toml)) | `soroban-sdk` = `"22.0.0"` |
+| `cargo-budget-report` ([manifest](cargo-budget-report/Cargo.toml)) | `stellar-xdr` = `"22.1.0"` (used for decoding transaction simulation responses; no direct `soroban-sdk` dependency) |
+
 * **Corresponding Stellar Protocol**: **Protocol 22**
+
+### What "Supported" means here
+
+A row marked **Supported** means: every workspace crate builds and passes `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` in CI on each push/PR to `main` ([quality.yml](.github/workflows/quality.yml), [budget.yml](.github/workflows/budget.yml)) — which compiles both pinned `soroban-sdk` versions and runs the Tier A macro test suite against the `amm-pool-contract` fixture. Additionally, the network-side figures in [MEASUREMENTS.md](MEASUREMENTS.md) were captured manually against Soroban testnet with these pins (one-time verification, not continuous CI). A row marked **Untested** has neither CI coverage nor manual verification.
 
 ### Compatibility Matrix
 
 | SDK Version | Protocol Version | Status | Notes |
 | :--- | :--- | :--- | :--- |
 | **`< 22.0.0`** | `< 22` | **Untested** | Older protocols may use different transaction/resource schemas. |
-| **`22.0.x`** | `22` | **Supported** | Matches pinned manifest dependencies (`soroban-sdk` `22.0.11`, `stellar-xdr` `22.1.0`). |
-| **`>= 23.0.0`** | `>= 23` | **Untested** | Future protocol upgrades or XDR schema changes (e.g. key/field renames) may break parsing. |
+| **`22.0.x`** | `22` | **Supported** | Matches all pinned manifest dependencies: `soroban-sdk` `22.0.11` (`amm-pool-contract`), `soroban-sdk` `22.0.0` (`host-function-contract`), `stellar-xdr` `22.1.0` (`cargo-budget-report`). Note that the two fixtures pin different patch versions of the same minor line; whether to unify them is a separate concern not covered by this table. |
+| **`>= 23.0.0`** | `>= 23` | **Untested** | Future protocol upgrades or XDR schema changes (e.g. key/field renames) may break parsing. Migration to newer SDK/XDR versions is actively worked on — see [#382](https://github.com/Tollcraft/soroban-budget-assert/issues/382) (soroban-sdk/stellar-xdr migration) and [#383](https://github.com/Tollcraft/soroban-budget-assert/issues/383) (wasmparser migration) — so the project is not stuck on protocol 22. |
 
 ---
 


### PR DESCRIPTION
Closes #464

## Summary

The README's compatibility table is the first thing a prospective user reads before adopting this tool, and it made a specific, checkable claim that did not match the workspace. This PR corrects every version claim in the "Supported Versions & Compatibility" section against the manifests — which are the source of truth for intent — and leaves all dependency versions untouched (this is a documentation-only fix).

## Claims checked and findings

| # | Claim in README (before) | What I checked | Finding | Action |
|---|---|---|---|---|
| 1 | "Supported SDK Version: \`soroban-sdk\` = \`\"22.0.11\"\` (specifically tested/resolved to 22.0.11 in \`Cargo.lock\`)" | \`amm-pool-contract/Cargo.toml:11\`, \`host-function-contract/Cargo.toml:11\` | **Wrong and incomplete.** The workspace pins *two different* SDK versions: \`amm-pool-contract\` uses \`22.0.11\`, \`host-function-contract\` uses \`22.0.0\`. The claim described one of the two. Citing \`Cargo.lock\` as the basis is also misleading — a lockfile records resolution, not intent. | Replaced the single-version bullet with a per-crate pin table linking each manifest; dropped the Cargo.lock rationale and explicitly named manifests as source of truth. |
| 2 | Table row \`22.0.x — Supported\`: "Matches pinned manifest dependencies (\`soroban-sdk\` \`22.0.11\`, \`stellar-xdr\` \`22.1.0\`)" | All three manifests, plus \`budget-core/Cargo.toml\` and \`budget-macros/Cargo.toml\` | **Partially wrong.** The note omitted the \`host-function-contract\` pin (\`22.0.0\`). \`budget-core\`/\`budget-macros\` have no Soroban dependencies, so nothing else was missing. The row's *range* (\`22.0.x\`) remains correct since both pins are on that line. | Row note now lists all three pins with the crate each belongs to. |
| 3 | Differing fixture pins | \`amm-pool-contract/Cargo.toml\` vs \`host-function-contract/Cargo.toml\` | The crates genuinely pin different patch versions of the same minor line (\`22.0.11\` vs \`22.0.0\`). Whether they *should* differ is unknowable from the repo alone, so per the issue guidance I did **not** assert intent. Unifying them would be a separate fix, out of scope here. | Table states the difference factually ("pin different patch versions of the same minor line") without claiming it is intentional. |
| 4 | \`>= 23.0.0 — Untested\` row said nothing about ongoing migration | Issues #382 ("migrate to soroban-sdk 27 and stellar-xdr 27", open) and #383 ("migrate cargo-budget-report to wasmparser 0.254", open) | A reader could conclude the project is stuck on protocol 22, when migration work is actively planned/in progress. | Row now links both issues and notes the migration is actively worked on. No migration work was performed — referenced only, per scope. |
| 5 | "Supported" had no defined basis | \`.github/workflows/quality.yml\`, \`.github/workflows/budget.yml\`, \`MEASUREMENTS.md\` methodology section | A support claim without a basis is not information. CI reality: every push/PR to \`main\` runs fmt/clippy/\`cargo test\` (which compiles both pinned SDK versions and runs the Tier A macro suite against \`amm-pool-contract\`); network-side figures were captured manually against testnet once, not continuously. | Added a "What \"Supported\" means here" subsection stating exactly what CI covers vs. what was one-time manual verification, and what Untested means. |
| 6 | Other version numbers elsewhere in README | Scanned full README for dotted version numbers / SDK / protocol references outside the table | None found — the only version claims were in this section (lines 68–78). Measurement figures (e.g. \`901,816\` instructions) and limit examples are data, not version claims. | No change needed. |

## What changed

- \`README.md\` only (+14/−4). No manifest, lockfile, or code changes.

### New structure of the section
1. Statement that the workspace does not pin a single SDK version + per-crate manifest dependency table (with links to each \`Cargo.toml\`)
2. Protocol 22 bullet retained
3. New "What 'Supported' means here" subsection (CI gates vs one-time manual testnet capture)
4. Corrected compatibility matrix, including migration-in-progress links on the \`>= 23\` row

## Verification

Per \`CONTRIBUTING.md\` quality standards (run locally, Rust 1.91.0):

- [x] \`cargo fmt --all -- --check\` — pass
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — pass
- [x] \`cargo build -p amm-pool-contract --release --target wasm32v1-none\` (prereq for Tier A tests, mirrors CI)
- [x] \`rustup target add wasm32-unknown-unknown\` (CI installs this; needed by \`cargo-budget-report\` integration tests)
- [x] \`cargo test --workspace\` — all 20 suites green

## Out of scope (deliberately untouched)

- The SDK/XDR migration itself (#382) and the wasmparser bump (#383)
- Any dependency version change — manifests are truth; README was wrong
- \`site/index.html\` footer text ("soroban-sdk v22.0.0"), which is outside this issue's scope (README-only) but worth a look during the #382 migration