### PR TITLE
ci/docs: dependency audit, wasm build cache, full CLI reference, testnet troubleshooting guide

### DIFF
--- a/.github/workflows/budget.yml
+++ b/.github/workflows/budget.yml
@@ -24,6 +24,22 @@ jobs:
           toolchain: 1.91.0
           targets: wasm32v1-none wasm32-unknown-unknown
 
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+        with:
+          # Pin the cache identity instead of taking the action's default key,
+          # which embeds the job name (`budget-check`). Renaming the job would
+          # otherwise silently discard every existing cache entry and pay a
+          # full cold compile again — see the sibling `soroban-cost-linter`
+          # repo's `lint.yml`, which hit the same problem.
+          shared-key: budget-check-wasm
+          # No `cache-directories` entry is needed here, unlike the sibling
+          # repo: `amm-pool-contract` builds via plain `cargo build --target
+          # wasm32v1-none`, with no `CARGO_TARGET_DIR` or per-crate target-dir
+          # override, so its wasm32v1-none output lands under the workspace's
+          # default `target/` — which this action already caches — rather
+          # than a separate directory the action wouldn't otherwise see.
+
       - name: Install System Dependencies
         run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config libudev-dev
 

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -37,6 +37,12 @@ jobs:
         # clippy/tests report success on them by never looking at them
         # (issue #451).
         run: scripts/check-module-reachability.sh
+      - name: Check CLI docs are up to date
+        # Fail if a flag added to cargo-budget-report/src/cli.rs has no
+        # mention at all in docs/src/reference.md. The reference used to
+        # cover only a fraction of the CLI's flags with nothing stopping
+        # the gap from reopening as flags were added (issue #434).
+        run: scripts/check-cli-docs.sh
       - name: Check for unused dependencies
         run: |
           cargo install cargo-machete --version 0.6.2 --locked

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,44 @@
+name: Security Audit (cargo-deny)
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "**/Cargo.lock"
+      - "**/Cargo.toml"
+      - "deny.toml"
+      - ".github/workflows/security.yml"
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "**/Cargo.lock"
+      - "**/Cargo.toml"
+      - "deny.toml"
+      - ".github/workflows/security.yml"
+  # A vulnerability can be disclosed against code that already merged, so a
+  # push/PR trigger alone is not enough — this runs daily so a new RustSec
+  # advisory against an already-vendored dependency is caught even when
+  # nothing in the repository changed.
+  schedule:
+    - cron: "17 4 * * *"
+  # Allow manual runs from the Actions tab.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  cargo-deny:
+    name: cargo-deny check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      # cargo-deny-action fetches its own Rust toolchain and cargo-deny
+      # binary internally, so no separate Rust/cargo-deny install step is
+      # needed here.
+      - name: Run cargo-deny
+        uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2
+        with:
+          command: check
+          log-level: warn

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,3 +22,20 @@ For general questions and community discussions, you can reach out via Telegram 
 **DISCLAIMER**: This project is an MVP developer tool and is **UNAUDITED**. 
 Do not use this software in production environments to govern significant financial value without conducting your own independent security review and audit.
 
+## Dependency Auditing
+
+Every dependency change is checked against the [RustSec Advisory Database](https://rustsec.org) by [`cargo-deny`](https://github.com/EmbarkStudios/cargo-deny), run in CI via [`.github/workflows/security.yml`](.github/workflows/security.yml):
+
+- **On every push and pull request** that touches `Cargo.lock`, any `Cargo.toml`, or the audit configuration itself.
+- **On a daily schedule**, since most vulnerabilities are disclosed after the code that depends on them has already merged — a schedule-only trigger is the only way to catch that case.
+- **On manual dispatch**, for an on-demand check outside those triggers.
+
+Policy lives in the committed [`deny.toml`](deny.toml): it fails the build on any RustSec vulnerability, unsoundness, or notice advisory; on yanked crates; and on dependency licenses outside the MIT/Apache-2.0-compatible allow-list. A finding is either fixed by updating the dependency, or explicitly accepted by adding its advisory ID to `deny.toml`'s `[advisories].ignore` list with a comment explaining why it does not apply — findings are never silenced just to get CI green.
+
+Run the same check locally with:
+
+```bash
+cargo install cargo-deny --locked
+cargo deny check
+```
+

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,99 @@
+# deny.toml — cargo-deny configuration for soroban-budget-assert
+#
+# This configuration audits dependencies for:
+#  - Security vulnerabilities via the RustSec advisory database
+#  - License compliance (MIT OR Apache-2.0 ecosystem standard)
+#  - Unmaintained or banned crates
+#
+# Run locally with: cargo deny check
+# CI uses EmbarkStudios/cargo-deny-action@v2 in .github/workflows/security.yml
+#
+# Modeled on the equivalent file in the sibling soroban-cost-linter repo,
+# adjusted for this workspace's dependency graph (no git dependencies here,
+# so [sources] denies all of them rather than allow-listing one).
+
+[graph]
+# Scan all workspace members with all features enabled to ensure local runs
+# match CI dependency auditing.
+all-features = true
+no-default-features = false
+
+# ------------------------------------ Advisories ------------------------------------
+# Security and maintenance checks via the RustSec Advisory Database
+# https://rustsec.org
+[advisories]
+# Vulnerability, unsound and notice advisories no longer have configurable lint
+# levels — cargo-deny always errors on them, and the only way to accept one is
+# to list its ID in `ignore` below with a justification.
+#
+# Which unmaintained crates to flag. "workspace" covers direct dependencies;
+# "all" additionally covers transitive ones, which pulls in advisories this
+# project cannot act on directly.
+unmaintained = "workspace"
+# A yanked crate is a supply-chain risk.
+yanked = "deny"
+# Advisory IDs to ignore. Each entry must carry a comment explaining why the
+# advisory does not apply, per this project's own audit policy (see
+# SECURITY.md): a finding is fixed or explicitly accepted with a reason, never
+# silenced to get a green tick.
+ignore = [
+    # Add entries like "RUSTSEC-2024-XXXX" with a comment explaining why the
+    # advisory does not apply to this project.
+]
+
+# ------------------------------------ Licenses ------------------------------------
+# Audit dependency licenses for compliance with ecosystem policies.
+# The Rust ecosystem standard is MIT OR Apache-2.0 — copyleft licenses like
+# GPL/AGPL are rejected to avoid encumbering downstream users.
+[licenses]
+# The `allow` list is exhaustive: anything not listed here is denied, and a
+# crate with no detectable license is denied too.
+#
+# This workspace pulls in the Soroban SDK and its crypto dependency tree
+# (ark-*, curve25519-dalek, ed25519-dalek, k256, p256, ...), which are all
+# MIT/Apache-2.0 dual-licensed in the current dependency graph — there is no
+# `ring`/`webpki`/`rustls` style ISC/OpenSSL license in this tree today. If
+# `cargo deny check` starts failing on a license not listed here, that is a
+# genuine new dependency to evaluate, not a config bug to route around.
+allow = [
+    "MIT",
+    "Apache-2.0",
+    # Unicode-3.0 — required by unicode-ident (transitive dep of syn/proc-macro2)
+    "Unicode-3.0",
+    # Apache-2.0 WITH LLVM-exception — reached transitively through the wasi
+    # crate. The LLVM exception only removes a restriction, so this is
+    # strictly more permissive than the plain Apache-2.0 already allowed above.
+    "Apache-2.0 WITH LLVM-exception",
+]
+# The precedence for determining which license applies when multiple are detected.
+confidence-threshold = 0.8
+
+# ------------------------------------ Sources ------------------------------------
+# Restrict where crates can be sourced from.
+[sources]
+# Allow crates from crates.io — the primary Rust package registry.
+unknown-registry = "deny"
+# This workspace has no git dependencies today; deny any that show up so a
+# supply-chain change of that shape gets caught rather than silently trusted.
+unknown-git = "deny"
+allow-git = []
+
+# ------------------------------------ Bans ------------------------------------
+# Block specific crates or versions known to be problematic.
+[bans]
+# Deny multiple versions of the same crate (encourages deduplication).
+multiple-versions = "warn"
+# Highlight crates that are widely duplicated — useful for keeping the
+# dependency graph lean.
+highlight = "all"
+# Wildcards are acceptable for dev/build dependencies, but production deps
+# should use precise versions.
+wildcards = "allow"
+
+# Crates denied outright. None currently, but add entries like:
+# { name = "some-crate", reason = "Explains why this crate is blocked" }
+deny = []
+
+# Specific version skips — use when one version of a crate is broken but
+# upgrading isn't immediately feasible.
+skip = []

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -4,6 +4,7 @@
 
 ## Getting Started
 - [End-User Guide](user_guide.md)
+- [Testnet Troubleshooting](testnet_troubleshooting.md)
 - [Protocol Mechanics](mechanics.md)
 - [Cost Terms Glossary](glossary.md)
 

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -329,19 +329,86 @@ println!("CPU: {cpu}, Memory: {mem}");
 cargo budget-report [--network <network>] [--source <source>] [--json] [--check]
 ```
 
-| Flag | Required | Meaning |
-|---|---|---|
-| `--network` | yes (flag or `budget.toml`) | Network to deploy and simulate against, e.g. `testnet` |
-| `--source` | yes (flag or `budget.toml`) | Funded identity used for deploy fees and as the simulation source |
-| `--json` | no | Emit the report as pretty-printed JSON instead of a table |
-| `--html` | no | Emit the report as a single self-contained HTML page — no external CSS, scripts, or fonts, so it renders from a `file://` URL and from a downloaded CI artifact. Rows mirror the JSON output; with `--check` each row also shows its limit and pass/fail status |
-| `--check` | no | Compare measured metrics against `cpu_limit` / `read_limit` / `write_limit` declared per function in `budget.toml`; print a per-function+metric pass/fail line and exit non-zero on any breach or failed configured simulation |
-| `--record <PATH>` | no | Record every transport response (deploy, invoke-build, simulate RPC) into a replayable fixture file at `PATH`. The run itself still talks to the network; the fixture lets a later `--replay` reproduce the same report offline. Mutually exclusive with `--replay` |
-| `--replay <PATH>` | no | Replay a run from a fixture written by `--record`. The whole pipeline runs offline — no `stellar` CLI, no `curl`, no network access — and the report is byte-identical to the recorded run. Mutually exclusive with `--record` |
+This section is the **complete** flag reference: every `#[arg(...)]` field declared on `BudgetReportArgs` in [`cargo-budget-report/src/cli.rs`][cli-rs] appears in the table below. [`scripts/check-cli-docs.sh`](#keeping-this-page-current) enforces that a newly added flag cannot be merged without at least a mention here, so the table cannot silently fall as far behind as it once had.
+
+[cli-rs]: https://github.com/Tollcraft/soroban-budget-assert/blob/main/cargo-budget-report/src/cli.rs
+
+### Full flag table
+
+| Flag | `budget.toml` equivalent | Default | Purpose |
+|---|---|---|---|
+| `--network <NETWORK>` | `network` | none — required from one source | Network to deploy and invoke against, e.g. `testnet` (passed straight through to the `stellar` CLI). CLI flag wins over the file; missing from both is a fatal error naming the field. **Does not** actually change what the simulate step targets — see [the discrepancy note](#--network-does-not-actually-route-the-simulate-step) below. |
+| `--source <SOURCE>` | `source` | none — required from one source | Funded Stellar identity used for deploy fees and as the simulation source. Same precedence as `--network`. |
+| `--json` | — | `false` | Emit the report as pretty-printed JSON instead of a table. Composes with `--check` (adds `limit`/`pass` per entry) and with `--record-baseline`/`--check-baseline` (see [Output-format precedence](#output-format-precedence-when-flags-combine)). |
+| `--csv` | — | `false` | Emit the report as CSV instead of a table. Header is `package,function,metric,value` normally, or `package,function,metric,value,limit,pass` under `--check`. Rows whose `value` never simulated are only included in `--check` mode (they carry `pass=false`); in the non-`--check` CSV they are omitted entirely, unlike the JSON/table output, which lists them. Takes priority over `--json`/`--html` if more than one is passed — see [below](#output-format-precedence-when-flags-combine). |
+| `--html` | — | `false` | Emit the report as a single self-contained HTML page — no external CSS, scripts, or fonts, so it renders from a `file://` URL and from a downloaded CI artifact. Rows mirror the JSON output; with `--check` each row also shows its limit and pass/fail status. |
+| `--check` | — | `false` | Compare measured metrics against `cpu_limit` / `read_limit` / `write_limit` declared per function in `budget.toml`; print a per-function+metric pass/fail line and exit non-zero on any breach or failed configured simulation. See [`--check`: enforcing regression limits](#--check-enforcing-regression-limits-against-network-verified-costs). |
+| `--color <auto\|always\|never>` | — | `auto` | When to colourise the plain-text `--check` report. Only meaningful together with `--check` — there is nothing to colourise otherwise, and callers gate on `args.check` before consulting it. See [the discrepancy note](#-color-does-not-actually-force-colour-into-a-pipe) below: `--color always` does **not**, despite its help text, force colour into a non-terminal output. |
+| `--quiet` | — | `false` | Suppress non-essential progress messages and warnings on stderr (build/deploy/simulate progress, retry notices). The final report is still printed to stdout; fatal errors (spawn failures, hard build failures) still go to stderr regardless. |
+| `--validate` | — | `false` | Re-decode each successful simulation's `SorobanTransactionData` XDR through `stellar xdr decode` and diff the result against the values this tool computed. Any discrepancy is reported as a diagnostic and the process exits non-zero. Silently **skipped** (not failed) when the Stellar CLI or its `xdr decode` subcommand is unavailable — this is a self-check against a second decoder, not a new data source. |
+| `--profile <PROFILE>` | — | `release` | Cargo build profile used to compile each contract's WASM (`cargo build --profile <PROFILE>`). A custom profile (e.g. `release-opt`) must already be defined in the workspace `Cargo.toml`; the tool does not validate that it exists before invoking `cargo build` with it. |
+| `--init` | — | `false` | Scaffold a commented `budget.toml` template at `./budget.toml` and exit immediately — no build, deploy, or simulation happens. Fails if `budget.toml` already exists unless `--force` is also passed. |
+| `--force` | — | `false` | Only meaningful with `--init`: allows overwriting an existing `budget.toml`. Ignored (has no effect on anything) when `--init` is not also passed. |
+| `--record-baseline <PATH>` | — | none | Write a new resource-usage baseline snapshot to `PATH` (conventionally `budget-baseline.toml`) and exit, instead of printing a report. Requires an explicit path argument — `--record-baseline` with no value is a clap parse error, not an implicit default filename. See [Step 6 of the End-User Guide](user_guide.md#step-6-optional-catch-regressions-on-the-workspace-with-a-baseline). |
+| `--check-baseline <PATH>` | — | none | Check current measurements against the baseline snapshot at `PATH`, applying the configured regression tolerance (`--tolerance` / `tolerance` / per-function override). Exits non-zero on any regression beyond tolerance. Mutually exclusive in effect with `--record-baseline` — passing both resolves to whichever `Mode` is checked first in `Mode::from_args` (record wins); do not rely on that ordering, pass only one. |
+| `--tolerance <F>` | `tolerance` (top-level) and `[functions.<name>].tolerance` (per-function) | `0.10` | Regression tolerance for `--check-baseline`, as a fraction (`0.10`) or a percentage (`"10%"`). CLI flag overrides the file's top-level `tolerance` — **except** a function's own `[functions.<name>].tolerance`, which outranks even this flag for that function. See [Value precedence](#value-precedence). |
+| `--max-retry-attempts <N>` | `[retry].max_attempts` | `4` | Total attempts (including the first) for deploy, invoke-build, and simulate-RPC calls before giving up. `1` disables retry entirely; `0` is rejected with an error. See [`retry`: transient-failure retry policy](#retry-transient-failure-retry-policy) and the [testnet troubleshooting guide](testnet_troubleshooting.md) for what actually gets retried. |
+| `--retry-backoff-secs <SECS>` | `[retry].initial_backoff_secs` | `2` | Initial backoff before the first retry; doubles on each subsequent attempt (2 → 4 → 8 with the defaults). |
+| `--derive-limits <OUT>` | — | none | Derive local (Tier A) test limits from a Tier B JSON report and write them as `KEY=VALUE` pairs to `OUT`, then exit — no build/deploy/simulate happens in this mode. Reads the Tier B report from `--from` (or stdin). Requires either all four `--margin-*` flags or a complete `[margin]` block in `budget.toml`; see [`margin`: deriving Tier A limits](#margin-deriving-tier-a-limits). |
+| `--from <PATH>` | — | stdin (`-`) | Source Tier B JSON report for `--derive-limits`. `-` (the default when omitted) reads from stdin, so `cargo budget-report --json \| cargo budget-report --derive-limits tier-a-limits.env --margin-cpu 1.5 ...` composes as a pipeline. Ignored outside `--derive-limits` mode. |
+| `--margin-cpu <F>` | `[margin].cpu_margin` | none | Multiplier applied to Tier B CPU values when deriving Tier A limits. Must be finite and `>= 1.0`. |
+| `--margin-memory <F>` | `[margin].memory_margin` | none | Multiplier applied to Tier B memory values. Same validity rule as `--margin-cpu`. |
+| `--margin-read <F>` | `[margin].read_margin` | none | Multiplier applied to Tier B read-bytes values. Same validity rule as `--margin-cpu`. |
+| `--margin-write <F>` | `[margin].write_margin` | none | Multiplier applied to Tier B write-bytes values. Same validity rule as `--margin-cpu`. All four `--margin-*` flags are all-or-nothing: supplying some but not all is an error listing the missing ones, and there is never a mix of CLI flags and a `[margin]` block — see [Value precedence](#value-precedence). |
+| `--provenance-out <PATH>` | — | `<OUT>` with `.env` replaced by `.md` | Only meaningful with `--derive-limits`: where to write the Markdown provenance table documenting how each derived limit was computed. Defaults from `--derive-limits`'s own `OUT` path (e.g. `tier-a-limits.env` → `tier-a-limits.provenance.md`), so it rarely needs to be set explicitly. |
+| `--record <PATH>` | — | none | Record every transport response (deploy, invoke-build, simulate RPC) into a replayable fixture file at `PATH`. The run itself still talks to the network; the fixture lets a later `--replay` run reproduce the same report offline. Mutually exclusive with `--replay` (rejected by clap's `conflicts_with` at parse time, before any network call happens). |
+| `--replay <PATH>` | — | none | Replay a run from a fixture file written by `--record`. The whole report pipeline runs offline: no `stellar` CLI, no `curl`, no network access, and preflight checks for those tools are skipped entirely. Mutually exclusive with `--record`. |
+
+### Flags that interact
+
+- **`--force` only does anything with `--init`.** Passing `--force` alone (no `--init`) is accepted by the parser but has no effect — it isn't read anywhere outside `scaffold_init`.
+- **`--csv` / `--json` / `--html` are mutually exclusive in effect, not by `conflicts_with`.** clap does not reject combining them; the renderer picks one output in a fixed priority order (`--csv` first, then `--json`, then `--html`, then the plain-text table). See [Output-format precedence](#output-format-precedence-when-flags-combine).
+- **`--record` and `--replay` *are* enforced as mutually exclusive** via clap's `conflicts_with`, so passing both is a parse-time error naming both flags — unlike the `--csv`/`--json`/`--html` case above.
+- **`--derive-limits` changes what every other network/build flag means.** In derive mode the tool never builds, deploys, or simulates anything; `--network`, `--source`, `--profile`, `--record`, `--replay`, and the retry flags are all irrelevant to that run. Only `--from`, `--margin-*`, and `--provenance-out` matter.
+- **`--record-baseline` / `--check-baseline` also short-circuit the legacy report path**, similarly to `--derive-limits`: `--json` still applies (it selects JSON vs. text rendering of the *baseline* report), but `--csv`, `--html`, and `--check` do not apply in these modes.
+- **`--tolerance` is overridden, not overriding, in one specific case**: a function's own `[functions.<name>].tolerance` in `budget.toml` wins even over an explicit `--tolerance` flag. Every other file-vs-flag precedence in this tool goes the other way (flag wins). See [Value precedence](#value-precedence).
+- **`--max-retry-attempts` / `--retry-backoff-secs`** apply identically whether or not `--record-baseline`/`--check-baseline`/`--derive-limits` are active, because they gate the same underlying deploy/invoke/simulate calls those modes still make (except `--derive-limits`, which makes none).
+
+### `budget.toml` fields vs. CLI flags: which one wins
+
+Every flag in the table above that has a `budget.toml` equivalent column entry follows the same rule unless noted: **the CLI flag wins when both are present.** The one documented exception is per-function `tolerance` (see above). The full precedence table, including the margin all-or-nothing rule, lives at [Value precedence](#value-precedence) later in this page — it is not repeated per-flag here to avoid two sources of truth drifting apart.
+
+### Output-format precedence when flags combine
+
+`--csv`, `--json`, and `--html` are not declared as mutually exclusive to clap (`--record`/`--replay` are, via `conflicts_with`; these three are not). Passing more than one is accepted, and the renderer picks exactly one output in this fixed order, checked top to bottom in the source:
+
+1. `--csv` (if set, nothing else is rendered)
+2. `--json` (if set and `--csv` was not)
+3. `--html` (if set and neither of the above was)
+4. plain-text table (the fallback when none of the three are set)
+
+So `cargo budget-report --csv --json` prints CSV only; `--json --html` prints JSON only. This is undocumented in the flags' own help text — verified by reading the rendering branch in `main.rs` rather than assumed.
+
+### `--color` does not actually force colour into a pipe
+
+`--color`'s own doc comment in `cli.rs` says `Always` will "always emit colour, even into pipes and files." That is not what the implementation does: `color_enabled_with` (the pure decision function backing `--color`, exhaustively unit-tested in `main.rs`) returns `false` whenever stdout is not a terminal or `NO_COLOR` is set, **before** it even looks at whether the choice was `Always`, `Auto`, or `Never`. A test in the same module asserts this directly: `--color always` piped to a file or another process produces no ANSI escapes. In practice `--always` and `--auto` currently behave identically; only `--never` is distinguishable from the other two. This looks like an intentional safety choice (never corrupt a file or a downstream parser with escape codes) that the help text's wording never caught up to — the behavior was not changed here, since changing flag behavior is out of scope for this page; only the discrepancy is reported.
+
+### `--network` does not actually route the simulate step
+
+`--network` selects the network for the `stellar contract deploy` and `stellar contract invoke --build-only` steps — those shell out to the `stellar` CLI with `--network <value>`, which resolves the name through the CLI's own network configuration correctly for `testnet`, `futurenet`, `local`, or any custom network. The final `simulateTransaction` RPC call does **not** go through the `stellar` CLI at all: `LiveTransport::simulate_transaction` in `live.rs` POSTs directly to a hardcoded `https://soroban-testnet.stellar.org:443`, regardless of what `--network` was set to. In practice this means:
+
+- `--network testnet` (the common case, and the only one this project's own CI and examples use) behaves as documented — deploy, invoke, and simulate all target the same network.
+- `--network futurenet`, `--network local`, or any other network deploys and builds the invocation correctly, but then simulates against testnet's RPC — which does not have the contract this run just deployed. Expect a simulation failure (see [Simulation failure](testnet_troubleshooting.md#simulation-failure-transaction-simulation-failed-or-similar)) that has nothing to do with the contract itself.
+
+This is a real functional gap, not just missing prose — no flag or `budget.toml` field currently changes which RPC endpoint `simulateTransaction` targets. It is reported here rather than fixed, since changing flag behavior is out of scope for this page.
+
+### Keeping this page current
+
+The real failure mode here is drift, not the one-time gap this page used to have: a flag added to `cli.rs` in a future PR with no corresponding row here. [`scripts/check-cli-docs.sh`](https://github.com/Tollcraft/soroban-budget-assert/blob/main/scripts/check-cli-docs.sh) is a CI-enforced drift check (wired into `quality.yml`) that derives every `--kebab-case` flag name from `cli.rs`'s `#[arg(...)]`-decorated fields and fails the build if any of them is not at least mentioned somewhere in this file. It catches a flag being completely undocumented; it cannot catch prose that is present but wrong, incomplete, or stale relative to the flag's actual behavior — that still needs human review, ideally by running the flag rather than trusting its `--help` text (see the `--color` and `--csv`/`--json`/`--html` findings above, both of which the flags' own help text does not mention).
 
 Configuration precedence: a CLI flag overrides the `budget.toml` value. If neither provides `network`/`source`, the command exits with an error naming the missing field.
 
-External requirements: the `stellar` CLI on `PATH`, a funded source identity on the target network, and the `wasm32-unknown-unknown` Rust target installed. `--replay` is the exception — it needs none of the network tooling (no `stellar`, no `curl`), only the workspace itself.
+External requirements: the `stellar` CLI on `PATH`, a funded source identity on the target network, and the `wasm32-unknown-unknown` Rust target installed. `--replay` is the exception — it needs none of the network tooling (no `stellar`, no `curl`), only the workspace itself. `--derive-limits`, `--init`, and `--record-baseline`/`--check-baseline` need neither network tooling nor a funded identity either, since none of them build, deploy, or simulate anything.
 
 ### Required release profile for comparable measurements
 

--- a/docs/src/testnet_troubleshooting.md
+++ b/docs/src/testnet_troubleshooting.md
@@ -1,0 +1,189 @@
+# Testnet Troubleshooting Guide
+
+Tier B (`cargo budget-report` without `--replay`) deploys a contract, funds an account through friendbot as part of that deploy, and simulates every exported function. Every one of those three steps can fail for reasons that have nothing to do with your contract's code. This page catalogs the failures you're likely to hit, what they mean, and what to do about each one — so a testnet blip doesn't send you searching your own contract for a bug that isn't there.
+
+{% hint style="info" %}
+Every entry below is labelled either **reproduced** — the exact wording quoted was produced by actually triggering the failure — or **from source** — the wording comes directly from the string literal in `cargo-budget-report/src/main.rs` or `live.rs`, quoted rather than paraphrased, but not independently triggered against a live testnet from this environment. Both are accurate; the label just tells you which kind of confidence to expect.
+{% endhint %}
+
+## First: is it hung, or is it retrying?
+
+Deploy, invoke-build, and the `simulateTransaction` RPC call are each wrapped in the same retry loop (`run_with_retry` in `main.rs`). By default that's **up to 4 attempts, with the delay before each retry doubling**: 2s → 4s → 8s. Unless `--quiet` is passed, every retry prints a line to stderr before it sleeps:
+
+```
+Deploy attempt 1/4 failed. Retrying in 2 s...
+Deploy attempt 2/4 failed. Retrying in 4 s...
+Deploy attempt 3/4 failed. Retrying in 8 s...
+```
+
+*(from source — the exact format string in `run_with_retry`.)*
+
+With the default settings, the worst case for a single call site is `2 + 4 + 8 = 14` seconds of sleeping before it gives up — bounded and predictable, not a hang. If your terminal has sat silent for longer than that with no new output and no exit, something other than the documented retry loop is going on (network still connecting, DNS still resolving) — that's a genuine hang, not this mechanism.
+
+To change this behavior:
+
+- `--max-retry-attempts N` (or `[retry].max_attempts` in `budget.toml`) — `1` disables retry entirely, useful when you want a fast, clear failure instead of a slow one.
+- `--retry-backoff-secs N` (or `[retry].initial_backoff_secs`) — changes the initial delay.
+
+See the [full retry policy reference](reference.md#retry-transient-failure-retry-policy) for the precedence between these and defaults.
+
+### Not every failure is retried
+
+The retry loop only re-attempts failures it classifies as **plausibly transient**. Everything else fails on the first try, on purpose — retrying a deterministic failure (a typo'd contract ID, a malformed argument) four times with growing delays would only make the eventual, unavoidable failure slower. The exact classifier (`is_transient_error` in `main.rs`) retries a message if it contains any of these substrings, case-insensitively:
+
+`rate limit`, `rate-limited`, `ratelimit`, `429`, `too many requests`, `connection`, `timed out`, `timeout`, `reset by peer`, `broken pipe`, `503`, `502`, `unavailable`, `temporarily`, `try again`
+
+Anything else — including a missing contract, a bad XDR, or an RPC-reported simulation error — is treated as permanent and fails immediately. This is the practical way to tell the two failure classes apart: **if you saw retry lines in the output, the tool already decided this looked transient; if it failed on attempt 1 with no retry lines, it decided the failure was deterministic** — which almost always means something in your configuration, not the network, needs fixing.
+
+## Your configuration vs. a bad network day
+
+The single fastest way to tell which kind of problem you have:
+
+| You see... | It usually means |
+|---|---|
+| Several `attempt N/4 failed. Retrying in ... s` lines, then final failure | The network (or friendbot) is having a bad day. Retrying later, or re-running, often just works. |
+| Failure on the very first attempt, no retry lines at all | Something in your setup is wrong in a way retrying cannot fix: a missing binary, an unfunded/misconfigured identity, a bad path, a bad argument. |
+
+Use the table below to go from the specific symptom to the specific cause.
+
+## Failure catalog
+
+### Friendbot rate limiting
+
+**Symptom:** Deploy fails, retries a few times with growing delays, then either succeeds or exhausts all 4 attempts with a final message like:
+
+```
+Failed to deploy amm-pool-contract after 4 attempts. Ensure your source account is funded.
+Last error: Error: friendbot rate-limited (try again later)
+```
+
+*(from source — `deploy_contract_with_retry`'s error format, combined with the friendbot wording the `stellar` CLI itself returns and that this project's own test fixture at `cargo-budget-report/tests/fixtures/fake_bin/stellar` deliberately reproduces for `MOCK_STELLAR_FAIL_COUNT` tests.)*
+
+**Cause:** Testnet's friendbot service rate-limits funding requests. Deploying a fresh (unfunded) source identity triggers a friendbot call as part of `stellar contract deploy`; under load, or when many CI jobs hit it in a short window, that call is throttled.
+
+**What to do:** This is the classic "bad network day" case — it's why the retry loop exists. Let the retries run; if all 4 still fail, wait a minute and re-run the command. If this happens constantly in CI, fund your source identity once ahead of time (`stellar keys generate alice --network testnet --fund`, or top it up manually) so deploy doesn't need friendbot on every run, and consider raising `--max-retry-attempts` for that job.
+
+### Friendbot / account not yet confirmed on-ledger
+
+**Symptom:** Same shape as rate limiting — deploy fails and retries — but the underlying cause is different: friendbot's funding transaction succeeded, but hasn't yet been confirmed by the ledger the deploy step queries. `main.rs`'s own comment on the retry constants names this explicitly as one of the two reasons deploy retry exists:
+
+> "when friendbot funding is suspected to have failed transiently (rate-limiting, network hiccups, or the account not being fully confirmed on-ledger yet)"
+
+*(from source, quoted directly.)*
+
+**Cause:** Ledger propagation delay between "friendbot accepted the funding request" and "the account is visible to the network for the deploy transaction."
+
+**What to do:** Identical to rate limiting — this is exactly what the exponential backoff is for. No action needed beyond letting the retries run; a source identity that was already funded before this run won't hit this path at all.
+
+### Friendbot / testnet unavailable
+
+**Symptom:** Deploy fails immediately or after retries with a connection-level error rather than an explicit rate-limit message — e.g. a `curl`/CLI-level connection failure surfacing through the same retry path.
+
+**Cause:** Testnet infrastructure (friendbot, RPC, or both) is down or unreachable, as opposed to just being slow or rate-limiting you.
+
+**What to do:** Check [Stellar's status page](https://status.stellar.org/) before assuming your setup is broken. If testnet itself is down, no flag or configuration change here will help — wait it out. This is the one case where even a `--max-retry-attempts` increase won't save you; the 14-second default window (or whatever you've configured) is meant to ride out a blip, not an outage.
+
+### RPC unreachable (`simulateTransaction`)
+
+**Symptom:** Simulation fails — either after retries, or immediately depending on the specific network condition — with a message shaped like:
+
+```
+simulateTransaction RPC failed: curl exited with status <code>: <stderr>
+```
+
+*(from source — the exact wrapper text in `LiveTransport::simulate_transaction`, `live.rs`.)*
+
+**Cause and reproduction:** This tool shells out to `curl -s -X POST ... https://soroban-testnet.stellar.org:443` directly (see the [`--network` discrepancy note](reference.md#--network-does-not-actually-route-the-simulate-step) — this URL is hardcoded and does not follow `--network`). **Reproduced** directly in this environment: `curl`'s `-s`/`--silent` flag suppresses its progress meter *and* its own error text, so a DNS or connection failure surfaces here as an exit status with an **empty** `<stderr>` — not silence from the tool hiding something, but `curl` genuinely not printing anything under `-s`:
+
+```
+$ curl -X POST -H "Content-Type: application/json" -d '{}' https://this-host-does-not-exist.invalid:443
+curl: (6) Could not resolve host: this-host-does-not-exist.invalid
+$ echo $?
+6
+```
+
+With `-s` (as this tool invokes it), that run produces exit code `6` and empty stderr — so the message you'll actually see is closer to `curl exited with status: 6` with nothing after the colon. The exit code is still the fastest way to identify the cause; the common ones from `curl(1)`:
+
+| Exit code | Meaning |
+|---|---|
+| `6` | Could not resolve host — DNS failure, no route to the RPC host |
+| `7` | Failed to connect — host resolved but refused the connection, or a firewall/proxy is blocking it |
+| `28` | Operation timeout — the host is reachable but not responding |
+| `35` | SSL/TLS connect error |
+
+**What to do:** This class of failure is in the retry classifier's transient list (`connection`, `timed out`, `timeout`, `unavailable` all match curl's own wording for these cases), so it retries automatically. If it still fails after all attempts: confirm outbound network access to `soroban-testnet.stellar.org:443` from wherever the tool is running (a CI runner's egress firewall is a common culprit — this is exactly the situation this project's own `budget.yml` sidesteps by mocking the Tier B step for fork pull requests, since forks don't have the network access or secrets Tier B needs), and confirm `curl` itself is on `PATH` and working (`curl --version`).
+
+### Simulation failure (`transaction simulation failed` or similar)
+
+**Symptom:** The run completes for other functions, but one specific function is skipped with a warning and reported as failed rather than crashing the whole run. The exact warning line depends on which of three sub-cases occurred (**from source**, the `match` on `SimulationFailure` around line 1684 of `main.rs`):
+
+```
+Warning: Simulation failed for <function>: <stellar CLI stderr>
+Warning: RPC error for <function>: <RPC "error" field contents>
+Warning: Failed to extract metrics for <function>: <parse error>
+```
+
+The report still prints for every function that succeeded; a fully failed run instead says `No successful simulations to report.` and exits `0` (**from source** — `main.rs`'s handling around `SimulationOutcome::Failed` and the "no successful simulations" message).
+
+**Cause:** `simulate_function` classifies this into the same three sub-cases as the warnings above, all reported as `SimulationFailure` rather than aborting the process (**from source**, `error.rs`):
+
+- **`Invoke`** (`Warning: Simulation failed for ...`) — `stellar contract invoke --build-only` itself failed (bad arguments in `[functions.<name>].args`, a function name that doesn't match the deployed contract's actual signature, etc.).
+- **`Rpc`** (`Warning: RPC error for ...`) — the `simulateTransaction` response body parsed fine, but its JSON carried an `"error"` field — the network answered, and the answer was "no." This is the case the [`--network` discrepancy](reference.md#--network-does-not-actually-route-the-simulate-step) produces when you deploy to a non-testnet network: the simulate step queries testnet for a contract ID that only exists on the network you actually deployed to, and testnet correctly reports it as unknown.
+- **`MetricsExtraction`** (`Warning: Failed to extract metrics for ...`) — the RPC responded successfully, but the expected `SorobanTransactionData` fields weren't where the tool expected them (a Protocol/SDK mismatch is the likely cause — see the [supported-versions table](reference.md#%EF%B8%8F-supported-versions--compatibility)).
+
+**What to do:** Check which sub-case you're in from the surrounding warning text. `Invoke` failures are almost always a `budget.toml` `[functions.<name>].args` problem — cross-check against the function's real signature. `Rpc` failures where you're confident the contract and function are right are the `--network` trap above — confirm you're on `testnet`. `MetricsExtraction` is worth filing as an issue; it usually means an SDK/protocol version this tool hasn't been updated for.
+
+### A contract that exports nothing simulatable
+
+Two distinct, silent-by-default cases, both worth knowing apart:
+
+**Case 1 — the package isn't a `cdylib` at all.** The tool discovers packages via `cargo metadata` and skips (with a plain Rust `continue`, no message of any kind) any package whose targets don't include a `cdylib` crate type (**from source**, the `is_cdylib` check in `main.rs`). If you expected a package to be built and simulated and it just never shows up anywhere in the output — not even a warning — check its `Cargo.toml` for:
+
+```toml
+[lib]
+crate-type = ["cdylib", "rlib"]
+```
+
+A package missing `cdylib` here produces **zero output about itself**, which is easy to mistake for "it ran and had nothing to report" rather than "it was never considered."
+
+**Case 2 — it's a `cdylib`, but the compiled WASM exports no simulatable functions.** Once a package does build as a `cdylib`, the tool parses the compiled WASM's export section and simulates every function export except names starting with `_` and the special `memory` export. If that leaves nothing, you get an explicit message this time:
+
+```
+No exported functions found in <package>
+```
+
+*(from source — the exact string in `main.rs`.)* This usually means every `pub fn` in the contract is either unintentionally private to the crate, or genuinely has no public entry points — check that your contract functions are on a `#[contractimpl]`-annotated `impl` block, which is what actually produces WASM exports for Soroban.
+
+### Missing or misconfigured identity
+
+**Symptom:** Deploy fails on the very first attempt — no retry lines — with a `stellar contract deploy failed: ...` message (**from source**, `LiveTransport::deploy_contract`'s error wrapper) whose actual text comes from the `stellar` CLI itself, not this tool. The tool cannot predict that text since it depends on the installed Stellar CLI version and your local identity configuration — this environment does not have the `stellar` CLI installed to reproduce it directly, so treat the CLI's own wording as authoritative over any paraphrase here.
+
+**Cause:** The identity named by `--source` (or `source` in `budget.toml`) either doesn't exist in your local Stellar CLI's keystore, or exists but isn't funded on the target network.
+
+**What to do:**
+- Confirm the identity exists: `stellar keys ls`.
+- Confirm it's funded on the network you're using: `stellar keys fund <name> --network testnet` (or generate + fund in one step: `stellar keys generate <name> --network testnet --fund`, as the [End-User Guide](user_guide.md#prerequisites) shows).
+- Because this fails on attempt 1 with no retry, it will **not** self-resolve by waiting — unlike the friendbot cases above, this needs a configuration fix before re-running.
+
+### Stellar CLI or the `wasm32` target isn't installed
+
+Not a network failure at all, but the tool checks for both before doing any network work (`run_preflight_checks` in `main.rs`, skipped entirely under `--replay`), specifically so a missing local tool doesn't masquerade as a network problem:
+
+```
+Stellar CLI is not installed or not on PATH.
+Install it with:  cargo install --locked stellar-cli
+See: https://github.com/stellar/stellar-cli
+```
+
+```
+wasm32-unknown-unknown target is not installed.
+Install it with:  rustup target add wasm32-unknown-unknown
+```
+
+*(from source, both exact strings.)* These fail immediately with no retry, since no amount of waiting installs a binary.
+
+## Summary: which page to reach for
+
+- **Wrong output, right network** (a check failed, a limit needs updating): see the [main Tool Reference](reference.md), not this page.
+- **Nothing works and you don't know why**: work top-to-bottom through [First: is it hung, or is it retrying?](#first-is-it-hung-or-is-it-retrying) to classify the failure, then jump to the matching entry in the [Failure catalog](#failure-catalog) above.
+- **Every flag's exact behavior**: the [CLI flag reference](reference.md#full-flag-table) documents all of them, including two behaviors (`--color`, `--network`) that this page and that one both link to because they directly affect how testnet failures show up.

--- a/docs/src/user_guide.md
+++ b/docs/src/user_guide.md
@@ -58,6 +58,8 @@ cargo budget-report
 
 The CLI finds every contract in the workspace, builds it to WASM, deploys to testnet, simulates every exported function, and prints one table of CPU instructions, read bytes, and write bytes. Use `--json` if you want to feed the numbers to a script.
 
+If this step fails partway through — friendbot funding, deploy, or simulation — see the [Testnet Troubleshooting Guide](testnet_troubleshooting.md) for what each failure means and how to resolve it.
+
 {% hint style="warning" %}
 This is not your transaction fee. The three metrics are inputs to the non-refundable resource fee; rent, refundable fees, transaction size, footprint entry counts, and the inclusion fee are not measured. If you are budgeting what users will actually pay — especially for a contract that writes persistent state, where rent often dominates — read [Measurement scope](reference.md#measurement-scope) first.
 {% endhint %}

--- a/scripts/check-cli-docs.sh
+++ b/scripts/check-cli-docs.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Check that every `#[arg(...)]`-declared flag of `cargo budget-report`
+# (cargo-budget-report/src/cli.rs) is documented in the CLI flag reference
+# (docs/src/reference.md).
+#
+# The reference page used to cover only a handful of the ~20+ flags defined
+# in `cli.rs`, and there was nothing to stop that gap from growing again as
+# new flags were added (see issue #434). This script is the drift check: it
+# derives each flag's `--kebab-case` name from its `cli.rs` field name and
+# fails if that literal string is missing from reference.md.
+#
+# This only catches *drift* (a flag with no mention at all) — it says
+# nothing about whether the prose documenting an existing flag is accurate
+# or complete. It cannot replace review of the actual English, only make an
+# omission impossible to merge unnoticed.
+#
+# Usage: scripts/check-cli-docs.sh
+#   exit 0 — every flag in cli.rs is mentioned in reference.md
+#   exit 1 — at least one flag is missing (listed on stdout)
+
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$root"
+
+cli_file="cargo-budget-report/src/cli.rs"
+ref_file="docs/src/reference.md"
+
+for f in "$cli_file" "$ref_file"; do
+    if [ ! -f "$f" ]; then
+        echo "check-cli-docs: expected file not found: $f" >&2
+        exit 1
+    fi
+done
+
+# Extract the field name declared on the first non-blank, non-comment line
+# after each `#[arg(...)]` attribute. `cli.rs` writes each attribute on its
+# own single line immediately above the field it decorates (`#[arg(long)]`
+# / `#[arg(long, value_name = "PATH")]` / etc.), so this is a plain
+# line-oriented scan rather than a real Rust parser. Written as a plain bash
+# loop (not awk) so it runs the same under gawk-less environments (macOS
+# ships the one-true-awk, Ubuntu's `awk` is mawk — neither supports the
+# 3-arg `match()` capture-group extension gawk provides).
+fields=()
+want=0
+while IFS= read -r raw_line; do
+    if [[ "$raw_line" == *'#[arg('* ]]; then
+        want=1
+        continue
+    fi
+    if [ "$want" -eq 1 ]; then
+        line="${raw_line#"${raw_line%%[![:space:]]*}"}" # trim leading whitespace
+        if [ -z "$line" ] || [[ "$line" == //* ]]; then
+            continue
+        fi
+        if [[ "$line" =~ ^pub[[:space:]]+([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*: ]]; then
+            fields+=("${BASH_REMATCH[1]}")
+        fi
+        want=0
+    fi
+done < "$cli_file"
+
+if [ "${#fields[@]}" -eq 0 ]; then
+    echo "check-cli-docs: found zero #[arg(...)] fields in $cli_file — parser likely broken" >&2
+    exit 1
+fi
+
+missing=0
+for field in "${fields[@]}"; do
+    flag="--${field//_/-}"
+    if ! grep -qF -- "$flag" "$ref_file"; then
+        echo "missing: $flag (cli.rs field \`$field\`) is not mentioned in $ref_file"
+        missing=1
+    fi
+done
+
+if [ "$missing" -ne 0 ]; then
+    echo ""
+    echo "Every #[arg(...)] flag in $cli_file must appear in $ref_file." >&2
+    exit 1
+fi
+
+echo "cli docs: all ${#fields[@]} flags in $cli_file are mentioned in $ref_file"


### PR DESCRIPTION
## Summary
fixes #429, fixes #432, fixes  #434, fixes  #435. Four independent, non-overlapping issues bundled into one branch/PR since they touch disjoint files; each is its own commit.

### #429 — dependency audit (`ci: add cargo-deny license/advisory scanning`)
- Adds `deny.toml`, modeled on the sibling `soroban-cost-linter` repo's config.
- Adds `.github/workflows/security.yml`: runs `cargo-deny` on push, PR, a daily schedule, and manual dispatch. The `cargo-deny-action` step is pinned to a resolved commit SHA (`EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25`, tag `v2`), matching this repo's existing convention of pinning third-party actions (see `cda39d5`).
- Updates `SECURITY.md` to describe the new check.
- No existing advisory findings to report — `cargo-deny` could not be run locally in this sandbox (no route to crates.io), so the first real signal will come from CI on this PR.

### #432 — cache the wasm build (`ci: cache cargo registry/build artifacts in budget-check`)
- Adds a `Swatinem/rust-cache` step to the `budget-check` job in `budget.yml`, with a pinned `shared-key` (mirrors the sibling `quality.yml` job's convention).
- A comment explains why no extra `cache-directories` entry is needed here, unlike the sibling repo: `amm-pool-contract`'s `wasm32v1-none` output lands under the default `target/`, which `rust-cache` already covers, rather than an out-of-tree directory.
- **Could not measure before/after job durations or verify cache-vs-rebuild correctness locally** — no crates.io access in this sandbox meant no local `cargo build` was possible. CI on this PR will show real before/after timings; please treat that as the verification the issue asks for rather than numbers quoted here.

### #434 — document all CLI flags (`docs: add full CLI flag reference with drift check`)
- `docs/src/reference.md` now documents all 26 `#[arg(...)]` fields in `cargo-budget-report/src/cli.rs`: name, purpose, default, example, and interactions (which flags only apply when another is set, `budget.toml` vs. CLI precedence, etc).
- Two behavior discrepancies found by reading source (not independently run against a live network, see #432 caveat):
  - `--color always` does not actually force color into a piped output despite its own doc comment saying it does — there's an existing unit test that confirms this behavior.
  - `--network` does not route the `simulateTransaction` RPC call; that call is hardcoded to `soroban-testnet.stellar.org` in `live.rs`.
  - The `--csv`/`--json`/`--html` output-format precedence was previously undocumented; it's now spelled out.
- `scripts/check-cli-docs.sh` cross-checks the flag count in `cli.rs` against the reference table and is wired into `.github/workflows/quality.yml`, so future drift fails CI instead of silently accumulating. Ran locally against the current `cli.rs`: `all 26 flags ... mentioned` — passes.

### #435 — testnet troubleshooting guide (`docs: add testnet troubleshooting guide`)
- New `docs/src/testnet_troubleshooting.md` covering: friendbot rate-limiting, unconfirmed-account, and unavailability; RPC unreachable; each `SimulationFailure` sub-case; the silent skip of non-cdylib crates vs. the explicit "no exported functions" message; missing/unfunded identities; and the retry/backoff behavior (4 attempts, 2s → 4s → 8s).
- Each entry is labelled **reproduced** (actually triggered, e.g. RPC-unreachable was reproduced locally with `curl` against a bad host) or **from source** (exact string literal quoted from `main.rs`/`live.rs`, not independently triggered from this sandbox).
- Linked from `docs/src/SUMMARY.md` and cross-linked from `docs/src/user_guide.md` Step 3, so a user hitting a failure mid-`cargo budget-report` finds the page from the guide itself.

## Note on local verification

This sandbox has no network route to crates.io (DNS resolves, connections are refused/403'd), so `cargo build`/`test`/`fmt`/`clippy`/`deny` could not be run locally against this branch. All changes are confined to TOML/YAML/Markdown/Bash — no Rust source was touched — and `scripts/check-cli-docs.sh` was hand-verified against `cli.rs`. **CI on this PR is the first real validation of the Rust-adjacent pieces** (the new `security.yml` workflow, and the cache behavior in `budget.yml`); please treat its results as authoritative over anything asserted above.

## Test plan
- [x] `scripts/check-cli-docs.sh` run locally: all 26 CLI flags confirmed present in `docs/src/reference.md`.
- [x] RPC-unreachable troubleshooting entry reproduced locally via `curl` against an invalid host.
- [ ] CI: `security.yml` runs cargo-deny cleanly (or surfaces real findings to address).
- [ ] CI: `budget-check` job in `budget.yml` completes with the new cache step; before/after timings visible in the Actions run.
- [ ] CI: `quality.yml`'s new drift-check step passes.
