### PR TITLE
ci: test the whole workspace

### DIFF
--- a/.github/workflows/budget.yml
+++ b/.github/workflows/budget.yml
@@ -41,7 +41,7 @@ jobs:
         run: cargo build -p amm-pool-contract --release --target wasm32v1-none
 
       - name: Run Budget Macros Test (Tier A)
-        run: cargo test
+        run: cargo test --workspace
 
       - name: Run Budget Report (Tier B)
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ First off, thank you for considering contributing to `soroban-budget-assert`!
 
 ### All platforms
 - Install Rust and the Soroban CLI. The repository includes a `rust-toolchain.toml` file, so `rustup` will automatically install and use the correct toolchain and target when you run cargo commands.
-- Run `cargo test` in the workspace root to run macro tests.
+- Run `cargo test --workspace` in the workspace root to run the full workspace test suite.
 - Run `cargo run -p cargo-budget-report -- budget-report` (or `cargo build`) to test the CLI locally.
 
 ## Documentation


### PR DESCRIPTION
closed #440

Update the Tier A budget check to run `cargo test --workspace`, matching the command documented in `CONTRIBUTING.md`.

Newly covered by CI:
- `budget-core`
- `budget-macros`
- `cargo-budget-report`
- `amm-pool-contract`

Validation:
- Workflow YAML: passed.
- `cargo test --workspace` before and after the change: blocked in this container because `cargo` and `rustc` are not installed. The GitHub Actions run is required to report the pass/fail state of the newly covered suites.