### PR TITLE
fix: enforce --json / --csv and --record-baseline / --check-baseline mutual exclusivity

### DIFF
--- a/cargo-budget-report/src/cli.rs
+++ b/cargo-budget-report/src/cli.rs
@@ -30,7 +30,7 @@ pub struct BudgetReportArgs {
     #[arg(long)]
     pub source: Option<String>,
 
-    #[arg(long, default_value_t = false)]
+    #[arg(long, default_value_t = false, conflicts_with = "csv")]
     pub json: bool,
 
     /// Enforce per-function limits declared in `budget.toml`.
@@ -49,12 +49,12 @@ pub struct BudgetReportArgs {
     pub csv: bool,
 
     /// Write a new resource-usage baseline snapshot to this path and exit.
-    #[arg(long)]
+    #[arg(long, conflicts_with = "check_baseline")]
     pub record_baseline: Option<String>,
 
     /// Check current measurements against an existing baseline snapshot at
     /// this path, applying the configured regression tolerance.
-    #[arg(long)]
+    #[arg(long, conflicts_with = "record_baseline")]
     pub check_baseline: Option<String>,
 
     /// Override the regression tolerance (e.g. "0.10" for 10%). Takes
@@ -204,4 +204,48 @@ pub enum ColorChoice {
     Always,
     /// Never emit colour.
     Never,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::error::ErrorKind;
+
+    #[test]
+    fn json_and_csv_are_mutually_exclusive() {
+        let err = CargoCli::try_parse_from([
+            "cargo",
+            "budget-report",
+            "--json",
+            "--csv",
+        ])
+        .expect_err("--json and --csv together should be rejected");
+        assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn json_alone_is_accepted() {
+        let result = CargoCli::try_parse_from(["cargo", "budget-report", "--json"]);
+        assert!(result.is_ok(), "--json alone should parse: {result:?}");
+    }
+
+    #[test]
+    fn csv_alone_is_accepted() {
+        let result = CargoCli::try_parse_from(["cargo", "budget-report", "--csv"]);
+        assert!(result.is_ok(), "--csv alone should parse: {result:?}");
+    }
+
+    #[test]
+    fn record_baseline_and_check_baseline_are_mutually_exclusive() {
+        let err = CargoCli::try_parse_from([
+            "cargo",
+            "budget-report",
+            "--record-baseline",
+            "out.json",
+            "--check-baseline",
+            "base.json",
+        ])
+        .expect_err("--record-baseline and --check-baseline together should be rejected");
+        assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
+    }
 }


### PR DESCRIPTION
## Summary

Passing `--json --csv` together previously emitted CSV silently, causing CI pipelines that pipe output into `jq` to fail downstream with a confusing error. The two flags are documented as mutually exclusive ("CSV instead of a table or JSON") but nothing enforced it at the clap level.

This fix adds `conflicts_with` attributes so clap rejects conflicting flag combinations with a clear error message and non-zero exit.

## Changes

### `cargo-budget-report/src/cli.rs`

1. **`--json` + `--csv`** — Added `conflicts_with = "csv"` to the `--json` arg. Now `cargo budget-report --json --csv` produces a clap error naming both flags and exits non-zero. Each flag alone behaves exactly as before.

2. **`--record-baseline` + `--check-baseline`** — Added `conflicts_with = "check_baseline"` on `--record-baseline` and `conflicts_with = "record_baseline"` on `--check-baseline`. These are clearly exclusive (you can't record a new baseline and check against one simultaneously).

3. **Unit tests** — Added 4 tests in `cli::tests`:
   - `json_and_csv_are_mutually_exclusive` — verifies `ArgumentConflict` error
   - `json_alone_is_accepted` — regression test
   - `csv_alone_is_accepted` — regression test
   - `record_baseline_and_check_baseline_are_mutually_exclusive` — verifies the other fix

## Flag pairs reviewed

| Pair | Action | Rationale |
|------|--------|-----------|
| `--json` / `--csv` | ✅ Fixed | Clearly exclusive output formats; doc comment says so |
| `--record-baseline` / `--check-baseline` | ✅ Fixed | Mutually exclusive by definition (record vs. check) |
| `--record` / `--replay` | ✅ Already handled | Already had `conflicts_with` on each other |
| `--derive-limits` / `--record-baseline` | Left alone | `derive_limits` returns early in `Mode::from_args` before baseline modes are evaluated; they don't actually conflict at runtime |
| `--check` with `--json`/`--csv`/`--html` | Left alone | These compose intentionally (e.g. `--check --json` shows pass/fail as JSON) |
| `--init` with output flags | Left alone | `--init` returns immediately; no meaningful runtime conflict |

## New error message

```
$ cargo budget-report --json --csv
error: the argument '--json' cannot be used with '--csv'
```

## Verification

- `cargo check` passes
- `cargo test` — all 336 unit tests + 15 integration tests + 7 pre-commit hook tests pass
- Each flag alone works exactly as before

Closes #497