### PR TITLE
feat(json): add schema version

### DIFF
--- a/cargo-budget-report/src/json_output.rs
+++ b/cargo-budget-report/src/json_output.rs
@@ -1,0 +1,53 @@
+use serde::Serialize;
+
+/// Current JSON schema version for budget report output.
+///
+/// Increment this value when the JSON structure changes in a way that
+/// requires consumers to update their parsing logic (see
+/// `docs/src/reference.md` for the full versioning policy).
+pub(crate) const SCHEMA_VERSION: u32 = 1;
+
+/// Top-level wrapper emitted by `cargo budget-report --json`.
+///
+/// Every JSON document produced by the budget report is an object with a
+/// `schema_version` integer and a `snapshots` array.  The individual
+/// snapshot objects are unchanged from the pre-versioning format.
+#[derive(Serialize)]
+pub(crate) struct BudgetReportJson<'a> {
+    pub(crate) schema_version: u32,
+    pub(crate) snapshots: &'a [crate::CostReport],
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::CostReport;
+
+    #[test]
+    fn budget_report_json_contains_schema_version() {
+        let reports = vec![CostReport {
+            package: "test-pkg".to_string(),
+            function: "test_fn".to_string(),
+            metric: "CPU Instructions",
+            value: Some(12345),
+            limit: None,
+            pass: None,
+        }];
+
+        let wrapper = BudgetReportJson {
+            schema_version: SCHEMA_VERSION,
+            snapshots: &reports,
+        };
+
+        let json = serde_json::to_value(&wrapper).unwrap();
+        assert_eq!(json["schema_version"], SCHEMA_VERSION);
+        assert!(json["snapshots"].is_array());
+        assert_eq!(json["snapshots"][0]["package"], "test-pkg");
+        assert_eq!(json["snapshots"][0]["value"], 12345);
+    }
+
+    #[test]
+    fn schema_version_matches_documented_current_version() {
+        assert_eq!(SCHEMA_VERSION, 1);
+    }
+}

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -921,20 +921,67 @@ Each simulated function produces four rows (or four JSON objects) when its simul
 
 Table output ends with a note that the values are simulated resource amounts rather than fees,
 what is not measured, and that testnet simulations vary slightly with ledger state — see
-[Measurement scope](#measurement-scope). JSON output (`--json`) is an array suited to CI:
+[Measurement scope](#measurement-scope). JSON output (`--json`) is an object with a schema
+version and a `snapshots` array suited to CI:
 
 ```json
-[
-  {
-    "package": "amm-pool-contract",
-    "function": "do_expensive_work",
-    "metric": "CPU Instructions",
-    "value": 756678
-  }
-]
+{
+  "schema_version": 1,
+  "snapshots": [
+    {
+      "package": "amm-pool-contract",
+      "function": "do_expensive_work",
+      "metric": "CPU Instructions",
+      "value": 756678
+    }
+  ]
+}
 ```
 
 When `--check --json` is used, configured functions gain `limit` and `pass` (see [the `--check` section above](#check-enforcing-regression-limits-against-network-verified-costs)); the shape for unconfigured functions is unchanged.
+
+### JSON schema version
+
+Every JSON document emitted by `cargo budget-report --json` includes a
+`schema_version` integer at the top level.  The current version is **1**.
+
+#### Versioning policy
+
+- The version is incremented when the JSON structure changes in a way
+  that requires consumers to update their parsing logic.  Adding a new
+  optional field to snapshot entries does **not** require a version bump;
+  removing or renaming a field, changing a field's type, or restructuring
+  the document **does**.
+- The `schema_version` field itself must always be present and must always
+  be an integer.
+- Consumers should read `schema_version` to decide which parsing branch
+  to use.  Unknown version numbers should be rejected with a clear error
+  rather than silently parsed.
+
+#### Breaking schema changes
+
+The following are considered breaking changes that require incrementing
+`schema_version`:
+
+- Removing, renaming, or changing the type of an existing field.
+- Changing the meaning of an existing field.
+- Moving snapshot entries out of the `snapshots` array.
+- Changing `schema_version` from an integer to another type.
+
+The following are **not** breaking and do **not** require a version bump:
+
+- Adding a new optional field to snapshot entries.
+- Adding a new top-level field alongside `schema_version` and `snapshots`.
+- Extending the set of possible `metric` values.
+
+#### Pre-version historical records
+
+Records produced before `schema_version` was introduced (i.e. records
+where the JSON is a bare array rather than a `{schema_version, snapshots}`
+object) are treated as **implicit version 0**.  The `record-history` CI
+job's measurement gate already accepts both forms — the bare array and
+the wrapped object — so existing historical data remains compatible
+without migration.
 
 ### HTML output (`--html`)
 


### PR DESCRIPTION
##close #404 

## Summary

Adds an explicit schema version to every JSON budget report.

## Changes

- Added the current JSON schema version to generated JSON output.
- Added a regression test verifying the version field and current version value.
- Documented the schema version and versioning policy.
- Documented how consumers should use the version when processing records.
- Documented how historical records created before schema versioning are treated.
- Preserved the existing JSON payload structure and fields.

## Compatibility

This is an additive change only.

Existing JSON fields and their structure remain unchanged. The `record-history` CI job was not modified, so existing consumers continue to receive the same data plus the new schema version field.

Schema versions will be incremented when a change is breaking for existing consumers, such as removing fields, changing field types, renaming fields, or changing the meaning of existing fields.

Non-breaking additive fields do not require a new major schema version.

## Historical records

Records created before schema versioning are treated according to the documented implicit version-zero policy. New records always include an explicit schema version.

Consumers processing historical data should use the version field when present and treat legacy records according to the documented version-zero compatibility rules.

## Tests

Added coverage verifying:

- schema version is always present;
- schema version matches the documented current value;
- existing JSON structure remains unchanged apart from the intentional version field.

## Validation

Ran:

```text
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace