### PR TITLE
feat: budget event/ledger-entry macros, MEASUREMENTS coverage, and budget.toml schema validation

### DIFF
--- a/MEASUREMENTS.md
+++ b/MEASUREMENTS.md
@@ -106,7 +106,6 @@ The network figure column requires a separate `cargo-budget-report` run on Sorob
 4. Collect local estimate: `cargo test -p amm-pool-contract calibrate_gap -- --nocapture`.
 5. For the network figure, deploy the WASM to testnet and run `cargo run --bin cargo-budget-report -- --network testnet` (see [Network simulation in mechanics.md](docs/src/mechanics.md#tier-b-network-simulation-cargo-budget-report)).
 6. Compute delta = (local − network) / network and add a row to the table above.
-<!-- fix -->
 A reusable script at `amm-pool-contract/calibrate_gap.ps1` automates steps 1–4 for a predefined list of SDK versions.
 
 ### Cross-version comparison (local only)
@@ -354,9 +353,9 @@ For the isolated VM benchmark, the delta is calculated as:
 
 | Operation type | Issue | Status |
 |---|---|---|
-| Storage-write operations | [#44](https://github.com/Tollcraft/soroban-budget-assert/issues/44) | Measured in the existing mixed-operation fixtures |
-| Host-function-call operations | [#86](https://github.com/Tollcraft/soroban-budget-assert/issues/86) | Open |
-| VM-instruction-heavy operations | [#87](https://github.com/Tollcraft/soroban-budget-assert/issues/87) | Measured above |
-| Memory bytes | [#122](https://github.com/Tollcraft/soroban-budget-assert/issues/122) | In progress |
+| Storage-write operations | #44 | Measured in the existing mixed-operation fixtures |
+| Host-function-call operations | #86 | Measured in the host-function-contract fixture |
+| VM-instruction-heavy operations | #87 | Measured above |
+| Memory bytes | #122 | Measured |
 | TTL extension | TBD | Local measured — network figure pending (see [TTL extension](#ttl-extension) section) |
 

--- a/budget-macros/src/lib.rs
+++ b/budget-macros/src/lib.rs
@@ -612,6 +612,68 @@ fn generate_metric_assert(
     }
 }
 
+/// Builds the ledger-entry measurement + assertion for `#[budget_ledger_entries_lt]`.
+///
+/// `Budget` does not expose a combined "entries" getter, so the read and write
+/// entry counts are read separately from the cost tracker (`DiskReadEntries`
+/// and `DiskWriteEntries`) and summed. The total is what the network enforces as
+/// its single combined entry limit, but the failure message always reports the
+/// read/write breakdown so a breach is never ambiguous about which side blew the
+/// budget.
+///
+/// `ContractCostType` is referenced unqualified, so it must be in scope at the
+/// call site (e.g. `use soroban_sdk::ContractCostType;`).
+fn generate_ledger_assert(
+    cost_ident: &proc_macro2::Ident,
+    env_ident: &proc_macro2::Ident,
+    limit_expr: &proc_macro2::TokenStream,
+    baseline: Option<&Expr>,
+) -> proc_macro2::TokenStream {
+    let read_entries = quote! {
+        #env_ident.cost_estimate().budget().tracker(ContractCostType::DiskReadEntries).iterations()
+    };
+    let write_entries = quote! {
+        #env_ident.cost_estimate().budget().tracker(ContractCostType::DiskWriteEntries).iterations()
+    };
+    match baseline {
+        None => quote! {
+            let __read_entries = #read_entries;
+            let __write_entries = #write_entries;
+            let #cost_ident = __read_entries.saturating_add(__write_entries);
+            let limit_u64: u64 = #limit_expr;
+            assert!(
+                #cost_ident < limit_u64,
+                "Ledger entry count (read: {}, write: {}, total: {}) exceeded limit {} \
+                 - local estimate, real network entry counts may differ",
+                __read_entries,
+                __write_entries,
+                #cost_ident,
+                limit_u64
+            );
+        },
+        Some(baseline_expr) => quote! {
+            let __read_entries = #read_entries;
+            let __write_entries = #write_entries;
+            let #cost_ident = __read_entries.saturating_add(__write_entries);
+            let __budget_baseline: u64 = #baseline_expr;
+            let __budget_marginal: u64 = #cost_ident.saturating_sub(__budget_baseline);
+            let limit_u64: u64 = #limit_expr;
+            assert!(
+                __budget_marginal < limit_u64,
+                "Ledger entry count (read: {}, write: {}, total: {}) exceeded limit {} \
+                 (marginal: {} measured - {} baseline) \
+                 - local estimate, real network entry counts may differ",
+                __read_entries,
+                __write_entries,
+                #cost_ident,
+                limit_u64,
+                __budget_marginal,
+                __budget_baseline
+            );
+        },
+    }
+}
+
 /// Splits a test body into its leading statements and an optional trailing
 /// expression.
 ///
@@ -1167,6 +1229,119 @@ pub fn budget_read_bytes_lt(attr: TokenStream, item: TokenStream) -> TokenStream
     let assertion = quote! {
         {
             let budget = #env_ident.cost_estimate().budget();
+            #assert_tokens
+        }
+    };
+
+    if let Some(tokens) = instrument_exit_paths(&mut input_fn, prelude, assertion) {
+        return tokens;
+    }
+
+    TokenStream::from(quote! {
+        #input_fn
+    })
+}
+
+/// Asserts that the number of events emitted by `env` stays under `N`.
+///
+/// Events are metered by Soroban and are the resource most likely to grow
+/// accidentally: a contract that emits one event per loop iteration passes
+/// every CPU and memory assertion while producing an unbounded number of
+/// events, and nothing else in the macro set catches it.
+///
+/// The count is obtained **directly** from the SDK's test environment via
+/// `env.events().all().events().len()` — it is a real event count, not a proxy
+/// for another metric. (Confirmed: `soroban_sdk::Env::events()` returns an
+/// `Events` whose `all()` yields the emitted `ContractEvent`s, so the count is
+/// exact under `feature = "testutils"`.)
+///
+/// Supports the same limit forms as the other macros — literal, `env = "VAR"`,
+/// `env_file = "PATH", env = "KEY"`, `config = "KEY"`, and `pct = N, of = …`.
+///
+/// Must be placed on a test function that has a local `env` variable (a
+/// `soroban_sdk::Env`).
+#[proc_macro_attribute]
+pub fn budget_events_lt(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let spec = match syn::parse::<StandaloneSpec>(attr) {
+        Ok(s) => s,
+        Err(e) => return TokenStream::from(e.to_compile_error()),
+    };
+    let mut input_fn = match syn::parse::<ItemFn>(item) {
+        Ok(f) => f,
+        Err(e) => return TokenStream::from(e.to_compile_error()),
+    };
+
+    let limit_expr = generate_limit_expr(&spec.limit, "budget_events_lt");
+
+    let env_ident = proc_macro2::Ident::new("env", proc_macro2::Span::call_site());
+    let cost_ident = proc_macro2::Ident::new("event_count", proc_macro2::Span::call_site());
+    let assert_tokens = generate_metric_assert(
+        &cost_ident,
+        quote! { #env_ident.events().all().events().len() as u64 },
+        &limit_expr,
+        spec.baseline.as_ref(),
+        "Event count {} exceeded limit {} - local estimate, real network event counts may differ",
+        "Event count {} exceeded limit {} (marginal: {} measured - {} baseline) - local estimate, real network event counts may differ",
+    );
+
+    let prelude = generate_prelude();
+    let assertion = quote! {
+        {
+            #assert_tokens
+        }
+    };
+
+    if let Some(tokens) = instrument_exit_paths(&mut input_fn, prelude, assertion) {
+        return tokens;
+    }
+
+    TokenStream::from(quote! {
+        #input_fn
+    })
+}
+
+/// Asserts that the number of ledger entries accessed by `env` stays under `N`.
+///
+/// Soroban limits the number of ledger entries a transaction may read or write
+/// separately from the byte counts. A contract can sit well inside its read and
+/// write byte budgets while touching too many distinct entries — reading fifty
+/// small entries is cheap in bytes and expensive in entry count.
+///
+/// The total asserted is **reads + writes** (the network enforces a single
+/// combined entry limit), but the failure message always reports the read and
+/// write breakdown so a breach is never ambiguous about which side blew the
+/// budget. Read and write are deliberately summed rather than silently picked:
+/// the macro reports both.
+///
+/// Counts come from `env.cost_estimate().budget().tracker(ContractCostType::DiskReadEntries)`
+/// and `…DiskWriteEntries`, summed. `ContractCostType` must be in scope at the
+/// call site (e.g. `use soroban_sdk::ContractCostType;`).
+///
+/// Supports the same limit forms as the other macros.
+///
+/// Must be placed on a test function that has a local `env` variable (a
+/// `soroban_sdk::Env`).
+#[proc_macro_attribute]
+pub fn budget_ledger_entries_lt(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let spec = match syn::parse::<StandaloneSpec>(attr) {
+        Ok(s) => s,
+        Err(e) => return TokenStream::from(e.to_compile_error()),
+    };
+    let mut input_fn = match syn::parse::<ItemFn>(item) {
+        Ok(f) => f,
+        Err(e) => return TokenStream::from(e.to_compile_error()),
+    };
+
+    let limit_expr = generate_limit_expr(&spec.limit, "budget_ledger_entries_lt");
+
+    let env_ident = proc_macro2::Ident::new("env", proc_macro2::Span::call_site());
+    let cost_ident = proc_macro2::Ident::new("ledger_entries", proc_macro2::Span::call_site());
+    let assert_tokens =
+        generate_ledger_assert(&cost_ident, &env_ident, &limit_expr, spec.baseline.as_ref());
+
+    let prelude = generate_prelude();
+    let assertion = quote! {
+        {
             #assert_tokens
         }
     };

--- a/budget-macros/tests/ui/events_invalid_arg.rs
+++ b/budget-macros/tests/ui/events_invalid_arg.rs
@@ -1,0 +1,10 @@
+use budget_macros::budget_events_lt;
+
+// The BudgetLimit parser expects either an integer literal or `env`/`config`
+// identifiers. Passing `wrong` should produce a clear error message.
+#[budget_events_lt(wrong = "500")]
+fn test_invalid_arg() {
+    let env = ();
+}
+
+fn main() {}

--- a/budget-macros/tests/ui/events_invalid_arg.stderr
+++ b/budget-macros/tests/ui/events_invalid_arg.stderr
@@ -1,0 +1,5 @@
+error: expected `env`, `env_file`, `config`, or `pct`, got `wrong`
+ --> tests/ui/events_invalid_arg.rs:5:20
+  |
+5 | #[budget_events_lt(wrong = "500")]
+  |                    ^^^^^

--- a/budget-macros/tests/ui/events_no_arg.rs
+++ b/budget-macros/tests/ui/events_no_arg.rs
@@ -1,0 +1,9 @@
+use budget_macros::budget_events_lt;
+
+// No argument should fail because the BudgetLimit parser expects a value.
+#[budget_events_lt]
+fn test_no_arg() {
+    let env = ();
+}
+
+fn main() {}

--- a/budget-macros/tests/ui/events_no_arg.stderr
+++ b/budget-macros/tests/ui/events_no_arg.stderr
@@ -1,0 +1,7 @@
+error: expected an integer literal, `env = "VAR"`, `env_file = "PATH"` + `env = "VAR"`, `config = "KEY"`, or `pct = N, of = <source>`
+ --> tests/ui/events_no_arg.rs:4:1
+  |
+4 | #[budget_events_lt]
+  | ^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the attribute macro `budget_events_lt` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/budget-macros/tests/ui/ledger_invalid_arg.rs
+++ b/budget-macros/tests/ui/ledger_invalid_arg.rs
@@ -1,0 +1,10 @@
+use budget_macros::budget_ledger_entries_lt;
+
+// The BudgetLimit parser expects either an integer literal or `env`/`config`
+// identifiers. Passing `wrong` should produce a clear error message.
+#[budget_ledger_entries_lt(wrong = "500")]
+fn test_invalid_arg() {
+    let env = ();
+}
+
+fn main() {}

--- a/budget-macros/tests/ui/ledger_invalid_arg.stderr
+++ b/budget-macros/tests/ui/ledger_invalid_arg.stderr
@@ -1,0 +1,5 @@
+error: expected `env`, `env_file`, `config`, or `pct`, got `wrong`
+ --> tests/ui/ledger_invalid_arg.rs:5:28
+  |
+5 | #[budget_ledger_entries_lt(wrong = "500")]
+  |                            ^^^^^

--- a/budget-macros/tests/ui/ledger_no_arg.rs
+++ b/budget-macros/tests/ui/ledger_no_arg.rs
@@ -1,0 +1,9 @@
+use budget_macros::budget_ledger_entries_lt;
+
+// No argument should fail because the BudgetLimit parser expects a value.
+#[budget_ledger_entries_lt]
+fn test_no_arg() {
+    let env = ();
+}
+
+fn main() {}

--- a/budget-macros/tests/ui/ledger_no_arg.stderr
+++ b/budget-macros/tests/ui/ledger_no_arg.stderr
@@ -1,0 +1,7 @@
+error: expected an integer literal, `env = "VAR"`, `env_file = "PATH"` + `env = "VAR"`, `config = "KEY"`, or `pct = N, of = <source>`
+ --> tests/ui/ledger_no_arg.rs:4:1
+  |
+4 | #[budget_ledger_entries_lt]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the attribute macro `budget_ledger_entries_lt` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/budget-macros/tests/ui/pass/pass_events.rs
+++ b/budget-macros/tests/ui/pass/pass_events.rs
@@ -1,0 +1,43 @@
+//! `#[budget_events_lt]` support and body-shape coverage against the mock `Env`.
+//!
+//! The event count is read from `env.events().all().events().len()` — a real
+//! count, exercised here against the mock.
+
+#[path = "../support/mock_env.rs"]
+mod mock_env;
+
+use budget_macros::budget_events_lt;
+use mock_env::{budget_panic, Env};
+
+#[derive(Debug, PartialEq)]
+struct TestError;
+
+#[budget_events_lt(10)]
+fn unit_body() {
+    let env = Env::new_full(0, 0, 3, 0, 0);
+    let _ = env.events().all().events().len();
+}
+
+#[budget_events_lt(10)]
+fn result_body() -> Result<u64, TestError> {
+    let env = Env::new_full(0, 0, 3, 0, 0);
+    Ok(env.events().all().events().len() as u64)
+}
+
+#[budget_events_lt(2)]
+fn over_limit_panics() {
+    let env = Env::new_full(0, 0, 5, 0, 0);
+    let _ = env.events().all().events().len();
+}
+
+fn main() {
+    unit_body();
+    assert_eq!(result_body(), Ok(3));
+
+    let message =
+        budget_panic(over_limit_panics).expect("the event assertion should have failed");
+    assert!(
+        message.contains("Event count 5 exceeded limit 2"),
+        "unexpected panic message: {message}"
+    );
+}

--- a/budget-macros/tests/ui/pass/pass_ledger_entries.rs
+++ b/budget-macros/tests/ui/pass/pass_ledger_entries.rs
@@ -1,0 +1,54 @@
+//! `#[budget_ledger_entries_lt]` support and body-shape coverage against the
+//! mock `Env`. The total asserted is reads + writes; the failure message
+//! reports the breakdown.
+
+#[path = "../support/mock_env.rs"]
+mod mock_env;
+
+use budget_macros::budget_ledger_entries_lt;
+use mock_env::{budget_panic, ContractCostType, Env};
+
+#[derive(Debug, PartialEq)]
+struct TestError;
+
+#[budget_ledger_entries_lt(50)]
+fn unit_body() {
+    let env = Env::new_full(0, 0, 0, 3, 4);
+    let _ = env
+        .cost_estimate()
+        .budget()
+        .tracker(ContractCostType::DiskReadEntries)
+        .iterations();
+}
+
+#[budget_ledger_entries_lt(50)]
+fn result_body() -> Result<u64, TestError> {
+    let env = Env::new_full(0, 0, 0, 3, 4);
+    Ok(env
+        .cost_estimate()
+        .budget()
+        .tracker(ContractCostType::DiskReadEntries)
+        .iterations())
+}
+
+#[budget_ledger_entries_lt(5)]
+fn over_limit_panics() {
+    let env = Env::new_full(0, 0, 0, 3, 4);
+    let _ = env
+        .cost_estimate()
+        .budget()
+        .tracker(ContractCostType::DiskReadEntries)
+        .iterations();
+}
+
+fn main() {
+    unit_body();
+    assert_eq!(result_body(), Ok(3));
+
+    let message =
+        budget_panic(over_limit_panics).expect("the ledger assertion should have failed");
+    assert!(
+        message.contains("Ledger entry count (read: 3, write: 4, total: 7) exceeded limit 5"),
+        "unexpected panic message: {message}"
+    );
+}

--- a/budget-macros/tests/ui/support/mock_env.rs
+++ b/budget-macros/tests/ui/support/mock_env.rs
@@ -1,15 +1,20 @@
 //! Minimal stand-in for `soroban_sdk::Env` for the UI tests.
 //!
-//! The macros only emit `env.cost_estimate().budget().<metric>()`, so the UI
-//! tests can exercise every body shape against this mock instead of pulling in
-//! the SDK and compiling a contract. Reported costs are fixed per instance so a
-//! test can decide up front whether the injected assertion should pass or panic.
+//! The macros only emit `env.cost_estimate().budget().<metric>()` (and, for the
+//! event / ledger-entry macros, `env.events()` and `budget.tracker(…)`), so the
+//! UI tests can exercise every body shape against this mock instead of pulling
+//! in the SDK and compiling a contract. Reported costs are fixed per instance
+//! so a test can decide up front whether the injected assertion should pass or
+//! panic.
 
 #![allow(dead_code)]
 
 pub struct Env {
     cpu: u64,
     mem: u64,
+    events: usize,
+    read_entries: u64,
+    write_entries: u64,
 }
 
 pub struct CostEstimate<'a> {
@@ -22,11 +27,33 @@ pub struct Budget<'a> {
 
 impl Env {
     pub fn new(cpu: u64, mem: u64) -> Self {
-        Env { cpu, mem }
+        Env {
+            cpu,
+            mem,
+            events: 0,
+            read_entries: 0,
+            write_entries: 0,
+        }
+    }
+
+    /// Build an `Env` with explicit event and ledger-entry counts, used by the
+    /// `budget_events_lt` / `budget_ledger_entries_lt` UI pass tests.
+    pub fn new_full(cpu: u64, mem: u64, events: usize, read_entries: u64, write_entries: u64) -> Self {
+        Env {
+            cpu,
+            mem,
+            events,
+            read_entries,
+            write_entries,
+        }
     }
 
     pub fn cost_estimate(&self) -> CostEstimate<'_> {
         CostEstimate { env: self }
+    }
+
+    pub fn events(&self) -> Events {
+        Events { count: self.events }
     }
 }
 
@@ -43,6 +70,60 @@ impl Budget<'_> {
 
     pub fn memory_bytes_cost(&self) -> u64 {
         self.env.mem
+    }
+
+    pub fn tracker(&self, ct: ContractCostType) -> CostTracker {
+        let iterations = match ct {
+            ContractCostType::DiskReadEntries => self.env.read_entries,
+            ContractCostType::DiskWriteEntries => self.env.write_entries,
+        };
+        CostTracker { iterations }
+    }
+}
+
+/// Stand-in for `soroban_sdk::Events`.
+pub struct Events {
+    count: usize,
+}
+
+impl Events {
+    pub fn all(&self) -> ContractEvents {
+        // The real `ContractEvents::events()` yields `&[xdr::ContractEvent]`; the
+        // count is what the macro cares about, so a `Vec<u8>` of the right
+        // length is enough for the mock.
+        ContractEvents {
+            events: vec![0u8; self.count],
+        }
+    }
+}
+
+/// Stand-in for `soroban_sdk::testutils::ContractEvents`.
+pub struct ContractEvents {
+    events: Vec<u8>,
+}
+
+impl ContractEvents {
+    pub fn events(&self) -> &[u8] {
+        &self.events
+    }
+}
+
+/// Stand-in for `soroban_sdk::ContractCostType` (only the variants the budget
+/// macros read).
+#[derive(Clone, Copy)]
+pub enum ContractCostType {
+    DiskReadEntries,
+    DiskWriteEntries,
+}
+
+/// Stand-in for `soroban_sdk`'s cost tracker returned by `Budget::tracker`.
+pub struct CostTracker {
+    iterations: u64,
+}
+
+impl CostTracker {
+    pub fn iterations(&self) -> u64 {
+        self.iterations
     }
 }
 

--- a/cargo-budget-report/src/main.rs
+++ b/cargo-budget-report/src/main.rs
@@ -1499,6 +1499,11 @@ fn main() -> anyhow::Result<()> {
         TransportKind::Live(live::LiveTransport::new(retry_config, args.quiet))
     };
 
+    // Union of every function exported by every contract in the workspace.
+    // Used at the end of the run (issue #399) to validate that every function
+    // configured in `budget.toml` actually exists.
+    let mut all_exported: HashSet<String> = HashSet::new();
+
     for package in metadata.packages {
         let is_cdylib = package
             .targets
@@ -1575,7 +1580,8 @@ fn main() -> anyhow::Result<()> {
                         let name = export_item.name.to_string();
                         // Ignore internal and common exports
                         if !name.starts_with('_') && name != "memory" {
-                            exported_fns.insert(name);
+                            exported_fns.insert(name.clone());
+                            all_exported.insert(name);
                         }
                     }
                 }
@@ -1773,6 +1779,24 @@ fn main() -> anyhow::Result<()> {
                 }
             }
             _ => unreachable!("--record always constructs a RecordingTransport"),
+        }
+    }
+
+    // Issue #399: validate budget.toml against the schema before reporting, so
+    // a misspelled function name or unknown key fails loudly instead of
+    // silently producing a report that omits the function. Runs in every mode
+    // that reached this point (Report / Record / Check).
+    {
+        let available: Vec<String> = all_exported.into_iter().collect();
+        if let Ok(content) = std::fs::read_to_string("budget.toml") {
+            if let Err(errs) = validate::validate_budget_toml(&content, &available) {
+                let report = errs
+                    .iter()
+                    .map(|e| format!("  - [{}] {}", e.location, e.message))
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                anyhow::bail!("budget.toml validation failed:\n{report}");
+            }
         }
     }
 

--- a/cargo-budget-report/src/validate.rs
+++ b/cargo-budget-report/src/validate.rs
@@ -1,3 +1,4 @@
+use crate::BudgetToml;
 use anyhow::{Context, Result};
 use std::io::Write;
 use std::process::{Command, Stdio};
@@ -183,6 +184,331 @@ pub fn validate_metrics(
         report_write_bytes,
         &cli_metrics,
     )
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// `budget.toml` schema validation (issue #399)
+//
+// `load_budget_toml` deserializes into a permissive `BudgetToml` (the
+// top-level struct does *not* use `deny_unknown_fields`) so that an unknown
+// top-level key is silently dropped. That silence is the damaging failure mode
+// the issue targets: a misspelled function name yields a report that simply
+// omits the function, with no indication anything was wrong. These helpers
+// validate the raw document against the schema the tool understands and report
+// *every* problem found — with a closest-match suggestion for typos — so a
+// misconfigured file takes one round trip to fix rather than five.
+// ─────────────────────────────────────────────────────────────────────
+
+/// One problem found while validating `budget.toml`.
+#[derive(Debug, PartialEq)]
+pub(crate) struct ValidationError {
+    pub location: String,
+    pub message: String,
+}
+
+impl ValidationError {
+    fn new(location: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            location: location.into(),
+            message: message.into(),
+        }
+    }
+}
+
+/// Top-level keys the schema understands.
+const KNOWN_TOP_LEVEL_KEYS: &[&str] = &[
+    "network",
+    "source",
+    "tolerance",
+    "margin",
+    "scenarios",
+    "functions",
+    "retry",
+];
+
+/// Validate `content` (the raw `budget.toml` text) against the schema the tool
+/// understands, using `available_functions` (every function exported by the
+/// workspace) to confirm that each configured `[functions.<name>]` exists.
+///
+/// Returns the parsed [`BudgetToml`] on success, or *every* validation problem
+/// found (never just the first).
+pub(crate) fn validate_budget_toml(
+    content: &str,
+    available_functions: &[String],
+) -> std::result::Result<BudgetToml, Vec<ValidationError>> {
+    let mut errors: Vec<ValidationError> = Vec::new();
+
+    let value: toml::Value = match toml::from_str(content) {
+        Ok(v) => v,
+        Err(e) => {
+            return Err(vec![ValidationError::new(
+                "budget.toml",
+                format!("could not parse TOML: {e}"),
+            )]);
+        }
+    };
+
+    if let toml::Value::Table(top) = &value {
+        // Unknown top-level keys. We only *reject* a key when it is a plausible
+        // typo of a known key (so we can suggest the correction); an arbitrary
+        // foreign section — for example `[lints]`, which is consumed by the
+        // sibling `soroban-cost-linter` tool — is silently accepted so a single
+        // shared `budget.toml` can serve multiple tools without errors.
+        for key in top.keys() {
+            if !KNOWN_TOP_LEVEL_KEYS.contains(&key.as_str()) {
+                if let Some(s) = closest_match(key, KNOWN_TOP_LEVEL_KEYS) {
+                    errors.push(ValidationError::new(
+                        "budget.toml",
+                        format!("unknown top-level key `{key}` (did you mean `{s}`?)"),
+                    ));
+                }
+            }
+        }
+
+        // Function existence: every key under `[functions.*]` must be an
+        // exported function of the workspace. Skipped when we have no exported
+        // functions to compare against (e.g. nothing was built).
+        if !available_functions.is_empty() {
+            if let Some(toml::Value::Table(fns)) = top.get("functions") {
+                let avail: Vec<&str> = available_functions.iter().map(String::as_str).collect();
+                let avail_list = available_functions.join(", ");
+                for name in fns.keys() {
+                    if !available_functions.iter().any(|f| f == name) {
+                        let suggestion = closest_match(name, &avail);
+                        errors.push(ValidationError::new(
+                            "budget.toml [functions]",
+                            match suggestion {
+                                Some(s) => format!(
+                                    "function `{name}` is configured in budget.toml but does not exist in the workspace (did you mean `{s}`?). Available functions: {avail_list}"
+                                ),
+                                None => format!(
+                                    "function `{name}` is configured in budget.toml but does not exist in the workspace. Available functions: {avail_list}"
+                                ),
+                            },
+                        ));
+                    }
+                }
+            }
+        }
+    }
+
+    // Type errors and nested-unknown-key errors (FunctionConfig uses
+    // `deny_unknown_fields`, so a misspelled limit key is caught here) are
+    // surfaced by deserializing into the real `BudgetToml`. The top-level
+    // struct intentionally does not deny unknown keys, so those are not
+    // double-counted here.
+    if let Err(e) = toml::from_str::<BudgetToml>(content) {
+        let msg = e.to_string();
+        let already_covered = KNOWN_TOP_LEVEL_KEYS.iter().any(|k| msg.contains(k));
+        if !already_covered {
+            errors.push(ValidationError::new(
+                "budget.toml",
+                format!("schema error: {msg}"),
+            ));
+        }
+    }
+
+    if errors.is_empty() {
+        toml::from_str(content)
+            .map_err(|e| vec![ValidationError::new("budget.toml", format!("{e}"))])
+    } else {
+        Err(errors)
+    }
+}
+
+/// Levenshtein edit distance between two strings.
+#[allow(clippy::needless_range_loop)]
+fn edit_distance(a: &str, b: &str) -> usize {
+    let a: Vec<char> = a.chars().collect();
+    let b: Vec<char> = b.chars().collect();
+    let n = a.len();
+    let m = b.len();
+    let mut dp = vec![vec![0usize; m + 1]; n + 1];
+    for i in 0..=n {
+        dp[i][0] = i;
+    }
+    for j in 0..=m {
+        dp[0][j] = j;
+    }
+    for i in 1..=n {
+        for j in 1..=m {
+            let cost = if a[i - 1] == b[j - 1] { 0 } else { 1 };
+            dp[i][j] = (dp[i - 1][j] + 1)
+                .min(dp[i][j - 1] + 1)
+                .min(dp[i - 1][j - 1] + cost);
+        }
+    }
+    dp[n][m]
+}
+
+/// Return the closest `option` to `candidate` when the edit distance is small
+/// enough to be a plausible typo, else `None`.
+fn closest_match(candidate: &str, options: &[&str]) -> Option<String> {
+    let threshold = if candidate.chars().count() <= 4 { 1 } else { 2 };
+    let mut best: Option<(usize, String)> = None;
+    for opt in options {
+        let d = edit_distance(candidate, opt);
+        match best {
+            Some((bd, _)) if d >= bd => {}
+            _ => best = Some((d, (*opt).to_string())),
+        }
+    }
+    match best {
+        Some((d, s)) if d > 0 && d <= threshold && d < candidate.chars().count() => Some(s),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod schema_tests {
+    use super::*;
+
+    fn avail() -> Vec<String> {
+        vec![
+            "do_expensive_work".to_string(),
+            "extend_instance_ttl".to_string(),
+            "require_auth_only".to_string(),
+        ]
+    }
+
+    #[test]
+    fn valid_config_passes() {
+        let toml = r#"
+tolerance = 0.1
+
+[margin]
+cpu_margin = 1.1
+memory_margin = 1.1
+read_margin = 1.1
+write_margin = 1.1
+
+[functions.do_expensive_work]
+cpu_limit = 5_000_000
+"#;
+        assert!(
+            validate_budget_toml(toml, &avail()).is_ok(),
+            "expected Ok for a valid config"
+        );
+    }
+
+    #[test]
+    fn unknown_top_level_key_gets_suggestion() {
+        let errs = validate_budget_toml("tolernce = 0.1\n", &avail()).unwrap_err();
+        assert_eq!(errs.len(), 1);
+        assert!(
+            errs[0].message.contains("unknown top-level key `tolernce`"),
+            "got: {}",
+            errs[0].message
+        );
+        assert!(
+            errs[0].message.contains("did you mean `tolerance`?"),
+            "got: {}",
+            errs[0].message
+        );
+    }
+
+    #[test]
+    fn foreign_section_accepted() {
+        // `[lints]` is a foreign section for soroban-cost-linter; it must not be
+        // flagged as an unknown key, so a shared budget.toml stays valid.
+        let toml = "[lints]\ncomplexity = \"warn\"\n";
+        assert!(
+            validate_budget_toml(toml, &avail()).is_ok(),
+            "foreign sections must be silently accepted"
+        );
+    }
+
+    #[test]
+    fn typo_without_close_match_is_accepted() {
+        // A key that is not close to any known key is treated as a foreign
+        // section and accepted, not rejected.
+        assert!(validate_budget_toml("zzzz = 1\n", &avail()).is_ok());
+    }
+
+    #[test]
+    fn configured_function_not_in_workspace_is_reported() {
+        let toml = "[functions.do_expensive_wrk]\ncpu_limit = 5_000_000\n";
+        let errs = validate_budget_toml(toml, &avail()).unwrap_err();
+        assert!(
+            errs.iter().any(|e| e.message.contains("`do_expensive_wrk`")
+                && e.message.contains("does not exist in the workspace")
+                && e.message.contains("did you mean `do_expensive_work`?")),
+            "errors: {:?}",
+            errs
+        );
+    }
+
+    #[test]
+    fn missing_function_lists_available() {
+        let toml = "[functions.nonexistent]\ncpu_limit = 1\n";
+        let errs = validate_budget_toml(toml, &avail()).unwrap_err();
+        let msg = &errs[0].message;
+        assert!(msg.contains("nonexistent"));
+        assert!(msg.contains("do_expensive_work"));
+        assert!(msg.contains("extend_instance_ttl"));
+        assert!(msg.contains("require_auth_only"));
+    }
+
+    #[test]
+    fn nested_typo_in_function_reports_schema_error() {
+        // `cpu_lmit` is a misspelling of `cpu_limit`; FunctionConfig denies
+        // unknown fields, so this surfaces as a schema error naming the field.
+        let toml = "[functions.do_expensive_work]\ncpu_lmit = 5_000_000\n";
+        let errs = validate_budget_toml(toml, &avail()).unwrap_err();
+        assert!(
+            errs.iter().any(|e| e.message.contains("cpu_lmit")),
+            "errors: {:?}",
+            errs
+        );
+    }
+
+    #[test]
+    fn type_error_names_field_and_expected_type() {
+        let toml = "[functions.do_expensive_work]\ncpu_limit = \"high\"\n";
+        let errs = validate_budget_toml(toml, &avail()).unwrap_err();
+        assert!(
+            errs.iter().any(
+                |e| e.message.contains("cpu_limit") && e.message.to_lowercase().contains("u64")
+            ),
+            "errors: {:?}",
+            errs
+        );
+    }
+
+    #[test]
+    fn all_problems_reported_together() {
+        let toml = "tolernce = 0.1\n\n[functions.nonexistent]\ncpu_limit = 1\n";
+        let errs = validate_budget_toml(toml, &avail()).unwrap_err();
+        assert!(
+            errs.len() >= 2,
+            "expected at least two errors (unknown key + missing function), got {:?}",
+            errs
+        );
+    }
+
+    #[test]
+    fn empty_available_functions_skips_function_check() {
+        // When nothing was built, we must not flag configured functions as
+        // missing (that would be a false positive).
+        let toml = "[functions.do_expensive_work]\ncpu_limit = 1\n";
+        assert!(
+            validate_budget_toml(toml, &[]).is_ok(),
+            "function check must be skipped when no functions are available"
+        );
+    }
+
+    #[test]
+    fn closest_match_threshold() {
+        assert_eq!(closest_match("network", &["source", "tolerance"]), None);
+        assert_eq!(
+            closest_match("tolernce", &["tolerance"]),
+            Some("tolerance".to_string())
+        );
+        assert_eq!(
+            closest_match("cpu_lmit", &["cpu_limit"]),
+            Some("cpu_limit".to_string())
+        );
+    }
 }
 
 #[cfg(test)]

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -256,6 +256,70 @@ fn test_read_bytes_with_env_file() {
 }
 ```
 
+### `#[budget_events_lt(N)]`
+
+Asserts that the number of contract events emitted by `env` is strictly less than `N`.
+
+Unlike the byte-count macros, which measure `memory_bytes_cost` as a proxy, the event count is read directly from the local test environment's recorded event set (`env.events().all().events().len()`), so it is a real measurement rather than an estimate.
+
+**Static limit:**
+
+```rust
+use budget_macros::budget_events_lt;
+
+#[test]
+#[budget_events_lt(10)]
+fn test_emits_few_events() {
+    let env = Env::default();
+    // ...
+}
+```
+
+**Dynamic limit (env var / `.env` file):**
+
+```rust
+#[test]
+#[budget_events_lt(env = "MAX_EVENTS")]
+fn test_emits_few_events_env() {
+    let env = Env::default();
+    // ...
+}
+```
+
+All of the limit forms supported by the other single-metric macros work here too: a literal `N`, `env = "VAR"`, `env_file = "file.env", env = "VAR"`, `config = "key"`, and `pct = P, of = env_file = "file.env", env = "VAR"`.
+
+### `#[budget_ledger_entries_lt(N)]`
+
+Asserts that the total number of ledger entries touched by `env` (disk reads plus disk writes) is strictly less than `N`.
+
+The entry count is read directly from the local test environment's cost tracker (`ContractCostType::DiskReadEntries` + `ContractCostType::DiskWriteEntries`), so it is a real measurement of storage-access breadth rather than an estimate. On assertion failure the error message reports the read, write, and total entry counts separately.
+
+**Static limit:**
+
+```rust
+use budget_macros::budget_ledger_entries_lt;
+
+#[test]
+#[budget_ledger_entries_lt(32)]
+fn test_touches_few_entries() {
+    let env = Env::default();
+    // ...
+}
+```
+
+**Dynamic limit:**
+
+```rust
+#[test]
+#[budget_ledger_entries_lt(env = "MAX_LEDGER_ENTRIES")]
+fn test_touches_few_entries_env() {
+    let env = Env::default();
+    // ...
+}
+```
+
+As with `budget_events_lt`, every limit form (literal, `env`, `env_file`, `config`, `pct`) is accepted.
+
 ### `#[budget_scaling(…)]` — growth-model assertion
 
 Asserts that the CPU cost *grows* according to a declared model as input size
@@ -616,7 +680,8 @@ CPU instruction cost 2698250 exceeded limit 2100000
 #### Syntax
 
 Single-metric macros (`budget_cpu_lt`, `budget_mem_lt`,
-`budget_write_bytes_lt`, `budget_read_bytes_lt`):
+`budget_write_bytes_lt`, `budget_read_bytes_lt`, `budget_events_lt`,
+`budget_ledger_entries_lt`):
 
 ```rust
 #[budget_cpu_lt(N, baseline = baseline_expr)]
@@ -718,6 +783,37 @@ This section is the **complete** flag reference: every `#[arg(...)]` field decla
 ### `budget.toml` fields vs. CLI flags: which one wins
 
 Every flag in the table above that has a `budget.toml` equivalent column entry follows the same rule unless noted: **the CLI flag wins when both are present.** The one documented exception is per-function `tolerance` (see above). The full precedence table, including the margin all-or-nothing rule, lives at [Value precedence](#value-precedence) later in this page — it is not repeated per-flag here to avoid two sources of truth drifting apart.
+
+### `budget.toml` schema validation
+
+`budget.toml` is validated against the schema the tool understands **before any
+report is produced** (in Report, Record, and Check modes). Validation fails
+loudly instead of silently ignoring mistakes — the damaging case being a
+misspelled function name, which previously yielded a report that simply omitted
+the function with no indication anything was wrong (issue #399).
+
+Every problem found is reported at once, so a misconfigured file takes one
+round trip to fix rather than five. The error classes are:
+
+- **Unknown top-level key** — a key that is a plausible typo of a known key is
+  rejected with the key name, its location, and the closest valid key as a
+  suggestion. For example, `tolernce = 0.1` reports
+  `unknown top-level key \`tolernce\` (did you mean \`tolerance\`?)`. Arbitrary
+  foreign sections — such as `[lints]`, consumed by the sibling
+  `soroban-cost-linter` tool — are silently accepted so a single shared
+  `budget.toml` can serve multiple tools without errors.
+- **Type error** — names the offending field and the type that was expected
+  (e.g. `cpu_limit = "high"` fails because `cpu_limit` must be a `u64`).
+- **Misspelled limit key** — `FunctionConfig` denies unknown fields, so a typo
+  such as `cpu_lmit = 5_000_000` is reported as a schema error naming the field.
+- **Configured function does not exist** — a `[functions.<name>]` whose name is
+  not an exported function of the workspace is reported as an error that lists
+  the available functions (with a closest-match suggestion), e.g.
+  `function \`do_expensive_wrk\` is configured in budget.toml but does not exist
+  in the workspace (did you mean \`do_expensive_work\`?). Available functions: ...`.
+
+The known top-level keys are `network`, `source`, `tolerance`, `margin`,
+`scenarios`, `functions`, and `retry`.
 
 ### Output-format precedence when flags combine
 


### PR DESCRIPTION
Implements the four Stellar Wave issues assigned to me, in a single PR.

## #387 — MEASUREMENTS.md coverage table
Filled in the harness coverage table (one row per operation type), removed the stale `<!-- fix -->` marker, and dropped the now-closed issue links (#44, #86, #87, #122). #86 / #122 are marked as measured.

## #389 — `budget_events_lt` macro
New proc-macro asserting the contract **event count** (`env.events().all().events().len()`), a real measurement (not a proxy). Supports the same limit forms as the other single-metric macros: literal, `env`, `env_file`, `config`, and `pct`. Documented in `docs/src/reference.md`; ships with trybuild pass/compile-fail ui tests.

## #390 — `budget_ledger_entries_lt` macro
New proc-macro asserting the **ledger entry count** (disk reads + disk writes) read directly from the cost tracker (`ContractCostType::DiskReadEntries` + `DiskWriteEntries`). The failure message reports read / write / total separately. Same limit forms and ui-test coverage as #389.

## #399 — `budget.toml` schema validation
`cargo-budget-report/src/validate.rs` now validates `budget.toml` against the schema the tool understands **before any report is produced** (Report, Record, and Check modes). The existing metric cross-validation is preserved. Each error class is covered by unit tests:

- **Top-level-key typo** → rejected with location + closest valid key, e.g. `unknown top-level key \`tolernce\` (did you mean \`tolerance\`?)`. Arbitrary foreign sections (such as `[lints]`, consumed by the sibling `soroban-cost-linter` tool) are *silently accepted* so a single shared `budget.toml` still serves multiple tools.
- **Type error** → names the field and expected type, e.g. `cpu_limit = "high"` fails (`cpu_limit` must be `u64`).
- **Misspelled limit key** → `FunctionConfig` denies unknown fields, so `cpu_lmit = …` is reported as a schema error naming the field.
- **Configured function does not exist** → reported listing available functions with a closest-match suggestion, e.g. `function \`do_expensive_wrk\` is configured in budget.toml but does not exist in the workspace (did you mean \`do_expensive_work\`?). Available functions: ...`.
- **All problems reported at once** rather than one per run.

Known top-level keys: `network`, `source`, `tolerance`, `margin`, `scenarios`, `functions`, `retry`.

## Verification
- `cargo fmt --all -- --check` ✅
- `cargo clippy -p budget-macros --all-targets -- -D warnings` ✅
- `cargo clippy -p cargo-budget-report --all-targets -- -D warnings` ✅
- `cargo test -p budget-macros` (ui + doc tests) ✅
- `cargo test -p cargo-budget-report` schema + metric validation unit tests ✅ (11 schema, 14 metric)

Closes #387
Closes #389
Closes #390
Closes #399