### PR TITLE
docs: surface architecture diagrams

### DIFF
--- a/architecture/README.md
+++ b/architecture/README.md
@@ -1,8 +1,9 @@
 # Architecture Diagrams
 
 Visual reference for the two primary subsystems in `soroban-budget-assert`.
-Both diagrams are authored in [Mermaid](https://mermaid.js.org/) and render
-natively on GitHub and GitBook.
+Both diagrams are authored in [Mermaid](https://mermaid.js.org/).
+
+**Note on Editing:** These diagrams are embedded directly in the Markdown pages of the documentation site so they render live without extra plugins. To edit them, modify the Mermaid source blocks directly in `docs/src/mechanics.md` and `docs/src/macro_architecture.md`. The `.mmd` files in this directory are kept as standalone backups and history references.
 
 ---
 

--- a/docs/src/macro_architecture.md
+++ b/docs/src/macro_architecture.md
@@ -83,6 +83,41 @@ soroban-budget-assert/
 
 ## Expansion Flow
 
+```mermaid
+graph TD
+    A["#[budget_cpu_lt(N)] or<br/>#[budget_cpu_lt(env = \"VAR\")]"]
+    A --> B["Proc-macro invoked at compile time<br/>by rustc"]
+
+    B --> C{Parse attribute tokens}
+
+    C -->|Integer literal| D["BudgetLimit::Int(N)<br/>limit_expr = quote! { N }"]
+    C -->|env = \"VAR\" syntax| E["BudgetLimit::EnvVar(VAR)<br/>limit_expr = quote! {<br/>  match budget_env_resolve(VAR) { … }<br/>}"]
+
+    D --> F[Parse test fn body via syn::ItemFn]
+    E --> F
+
+    F --> G["Inject preamble into fn body:<br/>let budget_env_resolve = |var| std::env::var(var).ok()"]
+
+    G --> H["Append cost-check epilogue:<br/>let budget = env.cost_estimate().budget();<br/>let cpu_cost = budget.cpu_instruction_cost();<br/>let limit_u64: u64 = limit_expr;<br/>assert!(cpu_cost < limit_u64, …)"]
+
+    H --> I["Emit rewritten fn tokens<br/>back to rustc"]
+
+    I --> J{Runtime: test executes}
+
+    J -->|cpu_cost < limit_u64| K["Test passes ✅"]
+    J -->|cpu_cost >= limit_u64| L["panic! with message:<br/>'CPU instruction cost N exceeded limit M<br/>- local estimate, real network cost<br/>may differ significantly in either direction'"]
+
+    L --> M{#[should_panic] present?}
+    M -->|Yes — deliberate regression fixture| N["Test passes ✅<br/>(expected failure documented)"]
+    M -->|No — real regression| O["Test fails ❌<br/>CI exits non-zero"]
+
+    style A fill:#1e3a5f,color:#fff,stroke:#4a90d9
+    style K fill:#1a4731,color:#fff,stroke:#2d7a4f
+    style N fill:#1a4731,color:#fff,stroke:#2d7a4f
+    style O fill:#5c1a1a,color:#fff,stroke:#c0392b
+    style L fill:#5c1a1a,color:#fff,stroke:#c0392b
+```
+
 ### 1. Attribute Macro Entry Point
 
 When rustc encounters:

--- a/docs/src/mechanics.md
+++ b/docs/src/mechanics.md
@@ -86,6 +86,54 @@ When the variable is unset, the limit defaults to `u64::MAX`, making the asserti
 
 The CLI measures ground truth. One invocation walks this pipeline:
 
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Dev as Developer
+    participant CLI as cargo budget-report
+    participant Cargo as Cargo / rustc
+    participant WASM as WASM Binary
+    participant Parser as WASM Parser
+    participant Stellar as Stellar CLI
+    participant RPC as Soroban RPC
+    participant Report as Budget Report
+
+    Dev->>CLI: cargo budget-report [--check] [--json]
+    CLI->>Cargo: cargo build -p <contract> --release<br/>--target wasm32-unknown-unknown
+    Cargo-->>WASM: amm_pool_contract.wasm (cdylib)
+
+    CLI->>Parser: wasmparser: scan exports
+    Parser-->>CLI: exported function names list
+
+    CLI->>CLI: Read budget.toml<br/>(network, source, per-function args/limits)
+
+    loop For each exported function in budget.toml
+        CLI->>Stellar: stellar contract invoke<br/>--function <fn> --args <args>
+        Stellar->>RPC: simulateTransaction (XDR)
+        RPC-->>Stellar: SimulateTransactionResponse<br/>(transactionData XDR)
+        Stellar-->>CLI: stdout JSON response
+
+        CLI->>CLI: Decode transactionData XDR<br/>Extract: CPU instructions,<br/>read bytes, write bytes
+
+        alt --check mode and limit configured
+            CLI->>CLI: Compare value vs cpu_limit /<br/>read_limit / write_limit
+            CLI-->>Report: PASS or FAIL per metric
+        else report-only mode
+            CLI-->>Report: Record value (no enforcement)
+        end
+    end
+
+    CLI->>Report: Render table (tabled) or<br/>emit JSON (--json flag)
+    Report-->>Dev: Console output +<br/>current_report.json artifact
+
+    alt Any limit breached or simulation failed
+        CLI-->>Dev: exit code 1 (CI fails)
+    else All checks pass
+        CLI-->>Dev: exit code 0 (CI passes)
+    end
+```
+
+
 1. **Discover** — runs `cargo metadata` and selects every workspace package with a `cdylib` target (i.e., every Soroban contract).
 2. **Build** — compiles each contract with `cargo build --target wasm32-unknown-unknown --release`, using the workspace's `[profile.release]`.
 3. **Scan exports** — parses the `.wasm` binary with `wasmparser` and collects every exported function, skipping internals (names starting with `_`, and `memory`).


### PR DESCRIPTION
**Summary**
Embedded and linked the two Mermaid architecture diagrams into the main documentation site to ensure they are visible and useful to readers. 

**What changed**
- Embedded `budget-cpu-lt-macro-expansion.mmd` into `docs/src/macro_architecture.md` directly under the "Expansion Flow" section.
- Embedded `cargo-budget-report-pipeline.mmd` into `docs/src/mechanics.md` directly under the "Tier B: Network simulation (cargo-budget-report)" pipeline list.
- Updated `architecture/README.md` to note that the diagrams are now embedded in the markdown files and should be edited there, ensuring developers know where the source of truth lives.

**Key design decisions**
- Since `.gitbook.yaml` has no explicit plugins required for mermaid, but `release_process.md` already successfully uses standard ````mermaid ```` codeblocks on the docs site, I embedded the mermaid sources directly rather than linking the `.mmd` files. This keeps the diagrams live and renders them perfectly alongside the prose.

**Acceptance-criteria checklist**
- [x] Both diagrams are reachable from the documentation site.
- [x] The macro-expansion diagram is embedded in `docs/src/macro_architecture.md`, next to the prose it illustrates.
- [x] The pipeline diagram is linked/embedded in `docs/src/mechanics.md`.
- [x] Both diagrams are checked against the code before being promoted.
- [x] `architecture/README.md` says what each diagram covers and how to regenerate or edit it.
- [x] The docs site renders Mermaid natively, so the sources are embedded directly.

**Notes for Follow-up**
- Checked both diagrams against the current codebase:
  1. The pipeline diagram depicts the *intent* (showing `Stellar` CLI hitting the RPC directly), whereas the actual code in `cargo-budget-report/src/live.rs` shells out to `curl` to perform the HTTP request. This discrepancy was noted in a separate open issue and is retained here to avoid out-of-scope redrawing.
  2. The macro-expansion diagram does not currently document the new `config = "key"` limit variant (only showing Integer and `env = "VAR"`).
- Since redrawing diagrams is explicitly out of scope for this PR, both are embedded as-is.

**Security note**
This PR only modifies documentation and does not alter the repository's code or dependencies.

Closes #479
