### PR TITLE
docs: correct UTC timestamp comments

### DIFF
--- a/cargo-budget-report/src/main.rs
+++ b/cargo-budget-report/src/main.rs
@@ -1239,20 +1239,13 @@ fn build_utc_timestamp() -> String {
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map_err(|e| Error::Message(format!("system time error: {e}")))
-        .map(|d| {
-            // Approximate UTC seconds-since-epoch using a 0-based
-            // bijection: 86400 seconds/day, 365.25 days/year. Good
-            // enough for an audit-trail timestamp; rounding to days
-            // would also be acceptable.
-            d.as_secs()
-        })
+        .map(|d| d.as_secs())
         .unwrap_or(0);
-    // The header timestamp is descriptive, not asserted, so it is
-    // fine to format it loosely. The string-form here is the
-    // seconds-since-epoch expressed in ISO-8601 by hand: the
-    // calendar math below is intentionally simple (no leap rules
-    // beyond the standard 4/100/400-year rule) and is sufficient
-    // for human-readable audit trail of when the derivation ran.
+    // The header timestamp is descriptive, not asserted. The string
+    // form is seconds-since-epoch expressed as ISO-8601 by hand using
+    // the proleptic Gregorian calendar and its standard 4/100/400-year
+    // leap-year rule, which is sufficient for this human-readable
+    // audit trail.
     format_unix_timestamp_as_iso8601(now)
 }
 


### PR DESCRIPTION
## Summary
- Correct the comments describing `build_utc_timestamp`.
- Remove the redundant `as_secs()` closure without changing behavior.

## Design decisions
- `duration_since(UNIX_EPOCH).as_secs()` is exact seconds since the Unix epoch, so the approximation wording was removed.
- The formatter uses the proleptic Gregorian calendar and the standard 4/100/400-year leap rule; the comment now says so directly.
- No date dependency or runtime behavior was added.

## Acceptance criteria
- [x] Comments describe the code that actually runs.
- [x] The 365.25-days-per-year approximation comment is gone.
- [x] The calendar note identifies the Gregorian leap rule.
- [x] No behavior change intended.
- [x] The redundant closure is removed.

## Verification
- `git diff --check` passed.
- `cargo fmt --all -- --check` could not run: `cargo` is not installed in the execution environment.
- `cargo clippy --workspace --all-targets -- -D warnings` could not run: `cargo` is not installed in the execution environment.
- `cargo test --workspace` could not run: `cargo` is not installed in the execution environment.

## Follow-ups
None known. The separate `unwrap_or(0)` concern remains out of scope for this documentation fix.

## Security
No secrets, dependencies, network behavior, or input handling changed.

Closes #504