### PR TITLE
Docs/explain cost gap

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -4,6 +4,7 @@
 
 ## Getting Started
 - [End-User Guide](user_guide.md)
+- [Local vs. Network Cost Gap](cost_gap.md)
 - [Testnet Troubleshooting](testnet_troubleshooting.md)
 - [Protocol Mechanics](mechanics.md)
 - [Cost Terms Glossary](glossary.md)

--- a/docs/src/cost_gap.md
+++ b/docs/src/cost_gap.md
@@ -1,0 +1,92 @@
+# Local vs. Network Cost Gap
+
+When developing Soroban smart contracts, locally measured resource costs (**Tier A**) differ from the costs billed by the Stellar network (**Tier B**). 
+
+Relying on a local estimate as a direct prediction of network cost creates a false sense of security. A budget check set tightly against local numbers can pass consistently in CI right up until it fails on-chain.
+
+This guide explains why this gap exists, how large it typically is across different operation types, which operations remain unmeasured, and how to set practical safety margins for your contract.
+
+> **Canonical evidence:** For the raw benchmark tables, JSON fixtures, SDK version calibration records, and step-by-step reproduction instructions, see the root [`MEASUREMENTS.md`](https://github.com/Tollcraft/soroban-budget-assert/blob/main/MEASUREMENTS.md) file and the [Measurements Reference](measurements.md).
+
+---
+
+## Why Local Estimates Differ from Network Costs
+
+Local tests run your contract inside a local test harness using `Env::cost_estimate().budget()`. Network costs, by contrast, are determined on-chain (or simulated via `simulateTransaction`) using the full host environment metering.
+
+The gap between local estimates and network reality is driven by three main factors:
+
+1. **Host VM vs. Test Harness Execution**: Local tests run in-process within the Rust test runner, whereas network simulations execute within the Soroban Host VM.
+   * *Note on Native Rust vs. WASM*: Running tests in native Rust (without registering compiled WASM) underestimates network costs by over 80%. **Only WASM-registered tests produce meaningful budget estimates.**
+2. **Build Profile Sensitivity**: The direction of the gap is not stable across compiler profiles. For example, on the same compute and storage benchmark:
+   * A size-optimized WASM build (`opt-level = "z"`, LTO enabled) produced a local estimate **19.2% higher** than the network figure (local overestimated).
+   * Cargo's default release build (`opt-level = 3`) produced a local estimate **7.8% lower** than the network figure (local underestimated).
+3. **SDK and Toolchain Version Shifts**: Internal changes to `soroban-sdk` and host metering models shift local estimates significantly across versions. For instance, upgrading from `soroban-sdk` 22 to 27 reduced local CPU instruction estimates for identical WASM logic by approximately **70%**.
+
+---
+
+## The Gap by Operation Type
+
+The magnitude and direction of the local-vs-network gap vary by operation type:
+
+| Operation Category | Observed Local-vs-Network Behavior | Typical Gap Magnitude |
+|---|---|---|
+| **VM Arithmetic (Compute-only)** | Local WASM tends to overestimate network CPU cost. | **+8.6%** (local overestimates) |
+| **Storage Writes** | Local WASM underestimates network CPU cost for storage writes. | **−17.2%** (local underestimates) |
+| **Host-Function Calls** | Local WASM systematically underestimates network CPU cost across host calls (e.g., `sequence()`, `timestamp()`, `sha256()`). | **−6.9% to −19.8%** (local underestimates) |
+| **Map Operations** | Local WASM underestimates network cost across insert, get, and iterate operations. | **−3.8% to −10.7%** (local underestimates) |
+
+### Key Scaling Behaviors
+
+* **Compute Loops**: Pure WASM arithmetic loops without host calls add no measurable cost to host budget metering. Budget consumption is driven by host calls and storage operations, not raw WASM loop iterations.
+* **Map Operations**: `Map::get` and `Map::iterate` exhibit constant per-operation marginal costs (~3,500 CPU instructions). However, `Map::remove` is **super-linear**: its per-operation cost grows as the map size increases (e.g., growing from ~5,400 CPU instructions at 100 entries to ~9,500 at 1,000 entries).
+
+---
+
+## ⚠️ Uncharacterised & Unmeasured Operations
+
+Not all Soroban operations have verified network deltas. The following operation types currently have pending or uncharacterised network gap figures:
+
+* **Memory Byte Allocations** (e.g., host-resident vector and object allocations)
+* **Storage Reads** (isolated from write phases)
+* **TTL Extensions** (instance and persistent storage lifetime extensions)
+* **Event Emissions** (emitting contract events)
+* **Authorization Checks** (`require_auth` calls isolated from contract logic)
+* **Cross-Contract Invocations** (multi-contract calls)
+
+> **Warning:** If your contract relies heavily on one of these unmeasured operations, **do not assume the CPU or storage-write gap figures apply**. The cost gap for uncharacterised operations is unknown, and local estimates must be treated with additional safety margins until validated via network simulation.
+
+---
+
+## Practical Guidance: Managing the Gap
+
+### When is a local estimate good enough?
+
+Local WASM assertions (**Tier A**) are fast, deterministic, and ideal for **CI regression gating**. They answer the question: *"Did this pull request accidentally double our CPU usage?"* 
+
+Local numbers are **not** good enough for establishing absolute network budget limits or fee guarantees.
+
+### How to choose safety margins
+
+To protect against unexpected on-chain failures:
+
+1. **Derive Limits from Network Simulations (Recommended)**: Use `cargo budget-report` (Tier B) on Soroban testnet to capture true network baseline figures, then generate Tier A limit files using `cargo budget-report --derive-limits`.
+2. **Use Metric-Specific Margins**: Do not use a single flat multiplier for all metrics. Configure separate multipliers in `budget.toml` (`[margin]`):
+   ```toml
+   [margin]
+   cpu_margin    = 1.50   # 50% buffer for CPU instruction drift
+   memory_margin = 1.25   # 25% buffer for memory bytes
+   read_margin   = 2.00   # 100% buffer for storage read bytes
+   write_margin  = 3.00   # 200% buffer for storage write bytes
+   ```
+3. **Local-Only Safety Buffer**: If you must set a Tier A assertion based purely on local WASM estimates (without a recent testnet report), add at least a **20% to 30% safety margin** above the measured local figure for standard operations, and a larger margin for host-function heavy or `Map::remove` workloads.
+4. **Re-derive on Dependencies and Profile Changes**: Re-measure and update limits whenever you bump `soroban-sdk`, update the Rust toolchain, or modify Cargo release profile flags.
+
+---
+
+## Related Documentation
+
+* [End-User Guide](user_guide.md) — Step-by-step setup for budget assertions and reports.
+* [Deriving Limits](deriving_limits.md) — How to automatically derive Tier A limits from Tier B network reports.
+* [Protocol Mechanics](mechanics.md) — Deep dive into macro instrumentation and CLI simulation pipelines.
+* [Measurements Reference](measurements.md) — Project benchmark data and SDK calibration history.

--- a/docs/src/mechanics.md
+++ b/docs/src/mechanics.md
@@ -25,7 +25,7 @@ lto = true
 These settings materially change the WASM being measured. `opt-level = "z"` and LTO optimize the binary shape, `codegen-units = 1` gives LLVM a broader optimization view, `panic = "abort"` removes unwinding paths, `strip = "symbols"` and `debug = 0` remove non-runtime payload, `debug-assertions = false` keeps release behavior, and `overflow-checks = true` preserves checked arithmetic. Cost figures from another release profile are not comparable: the measurements file records 901,816 local WASM CPU instructions / 756,678 testnet instructions for the size-optimized profile, versus 767,049 local / 832,006 testnet for Cargo's default release profile.
 
 {% hint style="info" %}
-The direction of the WASM gap is not stable — see the two build profiles compared in the [existing measurements](measurements.md#cpu-instructions), and the [SDK version calibration](measurements.md#sdk-version-calibration) which tracks how the gap shifts across soroban-sdk versions.
+The direction of the WASM gap is not stable — see the user guide on [Local vs. Network Cost Gap](cost_gap.md) for practical safety margin guidance, the two build profiles compared in the [existing measurements](measurements.md#cpu-instructions), and the [SDK version calibration](measurements.md#sdk-version-calibration) which tracks how the gap shifts across soroban-sdk versions.
 {% endhint %}
 
 Two conclusions drive the tool's design:

--- a/docs/src/user_guide.md
+++ b/docs/src/user_guide.md
@@ -66,7 +66,7 @@ This is not your transaction fee. The three metrics are inputs to the non-refund
 
 ## Step 4: Pin the costs into tests
 
-Add the macro crate to your contract's dev-dependencies, then gate a test. The macro asserts the *local* WASM estimate, so set the limit from a local measurement: run the test once unlimited, note the printed cost, and pin ~5% above it. Keep the Step 3 network number alongside it in a comment — local and network costs can differ by double-digit percentages in either direction, and the network number is the one that decides whether your transaction succeeds:
+Add the macro crate to your contract's dev-dependencies, then gate a test. The macro asserts the *local* WASM estimate, so set the limit from a local measurement: run the test once unlimited, note the printed cost, and pin ~5% above it. Keep the Step 3 network number alongside it in a comment — local and network costs can differ by double-digit percentages in either direction, and the network number is the one that decides whether your transaction succeeds. For detailed guidance on choosing safety margins and understanding operational gaps, see [Local vs. Network Cost Gap](cost_gap.md).
 
 ```rust
 use budget_macros::budget_cpu_lt;
@@ -101,6 +101,7 @@ fn test_expensive_function_budget() {
 Two details matter:
 
 {% hint style="warning" %}
+- **Local estimates differ from network costs.** A local check passing in CI does not guarantee network success. Read [Local vs. Network Cost Gap](cost_gap.md) to understand operation gaps and safety margins.
 - **Run the WASM, not raw Rust.** Raw Rust estimates ran ~81% below real network cost in our measurements; a limit asserted against them protects nothing.
 - **`reset_unlimited()` before the call**, so the default test budget doesn't cap the measurement.
 {% endhint %}


### PR DESCRIPTION
# docs: explain the local-vs-network cost gap for users

Closes #437 

### Summary

Adds a dedicated, user-focused documentation page (`docs/src/cost_gap.md`) explaining that locally measured Soroban budget estimates (**Tier A**) differ from true network billing (**Tier B**), and provides concrete guidance on how to choose safety margins.

`MEASUREMENTS.md` remains the canonical source of raw benchmark tables and calibration fixtures, while this new page gives contract developers a short, actionable explanation of the cost gap and practical decision-making guidance.

---

### What Changed

- **[NEW] `docs/src/cost_gap.md`**: Created a single-page user guide covering:
  - **Core Concept**: Why local estimates (`Env::cost_estimate().budget()`) differ from network billing (`simulateTransaction`), and why setting Tier A checks equal to local numbers creates false confidence.
  - **Root Causes**: In-process test runner vs. Host VM metering, Cargo build profile sensitivity (`opt-level="z"` overestimates by +19.2% while default release underestimates by -7.8%), and SDK version shifts (e.g. SDK 27 CPU costs dropping ~70% vs SDK 22).
  - **Empirical Gaps by Operation**: Quantifies typical deltas for VM arithmetic (+8.6%), storage writes (-17.2%), host functions (-6.9% to -19.8%), and map operations (-3.8% to -10.7%, noting `Map::remove`'s super-linear scaling).
  - **Uncharacterised Operations**: Explicitly warns users about operations with pending/unmeasured network deltas (TTL extensions, memory allocations, event emissions, authorization checks, cross-contract calls) so they don't assume CPU figures generalise.
  - **Practical Guidance**: When local estimates are good enough (CI regression gating) vs. how to configure metric-specific safety margins (`[margin]` in `budget.toml`) and local-only safety buffers (20%–30%+).
  - **Evidence Links**: Points to `MEASUREMENTS.md` and `measurements.md` for raw calibration tables and reproduction procedures.
- **`docs/src/SUMMARY.md`**: Added `[Local vs. Network Cost Gap](cost_gap.md)` to the Table of Contents under *Getting Started*.
- **`docs/src/user_guide.md`**: Added links and warning callouts pointing to `cost_gap.md` in Step 4 ("Pin the costs into tests").
- **`docs/src/mechanics.md`**: Linked `cost_gap.md` from the protocol mechanics documentation.

---

### Verification

- Pushed to branch `docs/explain-cost-gap` in 4 logical commits:
  1. `docs: add local vs network cost gap guide`
  2. `docs: add cost gap page to SUMMARY.md table of contents`
  3. `docs: link cost gap guide from user guide`
  4. `docs: link cost gap guide from protocol mechanics`
- Verified Markdown relative links resolve accurately across all updated docs.
