### PR TITLE
chore: refresh clippy MSRV note

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -10,10 +10,11 @@
 # moving under an unchanged source tree. Same reasoning as `rustfmt.toml`.
 #
 # Not set here:
-#   * `msrv` -- the project declares no `rust-version`, and the toolchain is
-#     unpinned. Pinning an MSRV belongs with the toolchain work (issue #113);
-#     setting one here would only silence version-gated suggestions based on a
-#     number nothing else in the repo enforces.
+#   * `msrv` -- the toolchain is pinned to 1.91.0, but the project declares no
+#     `rust-version` or supported minimum Rust version. The pin makes the lint
+#     environment reproducible; it does not establish an MSRV, so setting one
+#     here would still silence version-gated suggestions based on an
+#     uncommunicated support commitment.
 #   * `avoid-breaking-exported-api` -- left at its default (`true`). The crates
 #     here are a proc-macro library and a CLI binary, neither of which has an
 #     API surface stable enough to be worth linting against.


### PR DESCRIPTION
## Summary

- Refresh the `msrv` explanation in `clippy.toml`.
- Record that the Rust toolchain is pinned to `1.91.0`.
- Keep `msrv` unset because the workspace declares no `rust-version` or supported minimum Rust version.

## Issue addressed

Closes #505.

The previous note said the toolchain was unpinned and referred to issue #113 as pending. That is no longer accurate: `rust-toolchain.toml` pins channel `1.91.0`, and issue #113 is closed.

## Design decisions

- The `msrv` setting remains intentionally absent. A reproducible lint toolchain and a published MSRV are separate decisions; the repository does not currently communicate a Rust support window through `Cargo.toml`.
- The updated note explains that adding an arbitrary `msrv` would make Clippy suppress version-gated suggestions based on an unsupported commitment.
- No threshold values, `rust-toolchain.toml`, `rustfmt.toml`, or source code were changed.
- The existing toolchain/workflow version consideration is intentionally left out of scope; this change does not depend on choosing an MSRV.

## Acceptance criteria

- [x] The `msrv` note reflects that the toolchain is pinned.
- [x] The note states that no crate declares `rust-version` or a supported minimum Rust version.
- [x] The decision to leave `msrv` unset is explicitly restated.
- [x] The stale reference to issue #113 is removed.
- [x] Threshold values and `rustfmt.toml` are unchanged.

## Verification

- `git diff --check` passed.
- `cargo fmt --all -- --check` — not run successfully because `cargo` is unavailable in the execution environment (`cargo: command not found`).
- `cargo clippy --workspace --all-targets -- -D warnings` — not run successfully for the same environment limitation.
- `cargo test --workspace` — not run successfully for the same environment limitation.

CI should run the required Clippy gate using the repository's pinned Rust 1.91.0 toolchain.

## Security

No executable code, dependencies, secrets, toolchain configuration, or runtime behavior changed.