### PR TITLE
docs: consolidate Windows setup instructions (#229)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Consolidate Windows setup instructions (issue #229).** Made `CONTRIBUTING.md#windows` the single authoritative reference for Windows environment setup (including prerequisites, PowerShell/Git Bash choices, `wasm32v1-none` target, and PATH troubleshooting) and replaced the duplicate instructions in `docs/src/developer_guide.md` with a direct link.
 - Tier A reconciliation comments in `amm-pool-contract/tests/budget_test.rs` are now auto-generated from `tier-a-limits.provenance.md`, not transcribed by hand. Re-derive the artifact instead of editing the test inline when a limit needs to change.
 - `src/lib.rs` re-exports `module_25` alongside the existing `module_1`.
 

--- a/docs/src/developer_guide.md
+++ b/docs/src/developer_guide.md
@@ -13,45 +13,7 @@ This guide is for developers modifying or extending `soroban-budget-assert` itse
 
 ### Windows
 
-1. Clone the repository.
-2. Install [Rust](https://rustup.rs) — the `.exe` installer adds `rustup` and `cargo` to your `PATH`.
-3. Install [Git for Windows](https://git-scm.com/download/win) — includes Git Bash for the pre-commit hook.
-4. Install the [Visual C++ Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/) — required to compile `stellar-cli`.
-5. Open **PowerShell** and run:
-
-```powershell
-# Add the WASM target
-rustup target add wasm32v1-none
-
-# Install the Stellar CLI
-cargo install --locked stellar-cli
-
-# Create and fund a testnet identity
-stellar keys generate alice --network testnet --fund
-```
-
-6. Build the contract WASM and run tests:
-
-```powershell
-cargo build -p amm-pool-contract --release --target wasm32v1-none
-cargo test --workspace
-```
-
-#### PATH troubleshooting
-
-If `stellar` or `cargo` is not found after installation:
-
-```powershell
-# Check if ~/.cargo/bin is on PATH
-$env:PATH -split ';' | Select-String '.cargo'
-
-# Add it permanently (restart terminal afterward)
-[Environment]::SetEnvironmentVariable(
-    "PATH",
-    "$env:PATH;$env:USERPROFILE\.cargo\bin",
-    [EnvironmentVariableTarget]::User
-)
-```
+For setup on Windows (PowerShell or Git Bash), including prerequisite links, WASM target installation, and PATH troubleshooting, see the authoritative guide in [CONTRIBUTING.md#windows](../../CONTRIBUTING.md#windows).
 
 ## Workspace structure
 
@@ -84,15 +46,6 @@ cargo test
 - `test_budget_extend_ttl_*` (4 tests) — CPU and memory budget assertions for `extend_instance_ttl` calls with passing and deliberate-regression variants.
 - `test_read_bytes_budget_*` / `test_write_bytes_*` (5 tests) — ledger read-bytes budget enforcement, write-bytes budget via `#[budget_write_bytes_lt]`, and deliberate-regression fixtures.
 - `test_budget_macro_result_returning` / `test_budget_macro_result_returning_regression` / `test_budget_macro_early_return_still_asserts` — the `Result`-returning and early-`return` body shapes.
-`amm-pool-contract/tests/budget_test.rs` covers the macros against the real SDK `Env`:
-
-- `test_budget_raw_rust` / `test_budget_wasm` — print raw-Rust vs. WASM local cost estimates (the source of the measured-gap figures in Mechanics).
-- `test_budget_macro_gated` — a passing assertion at the 950,000 CPU limit.
-- `test_budget_macro_deliberate_regression` — asserts an intentionally low limit (600,000) and expects the macro's panic, proving the gate fires.
-- `test_budget_macro_dynamic_env` — asserts a CPU limit read from the `TEST_MAX_CPU` environment variable.
-- `test_budget_macro_dynamic_env_fallback` — verifies the fallback behaviour: when the env var is unset, the limit defaults to `u64::MAX` and the assertion passes unconditionally.
-- `test_budget_macro_json_config_*` — the `config = "key"` limit form read from `budget.json`.
-- `test_budget_macro_result_returning` / `..._regression` / `test_budget_macro_early_return_still_asserts` — the `Result`-returning and early-`return` body shapes.
 
 `budget-macros/tests/ui.rs` is a `trybuild` suite that needs no WASM and no SDK. `tests/ui/*.rs` must fail to compile, with the diagnostic pinned in the matching `.stderr` — regenerate those with `TRYBUILD=overwrite cargo test -p budget-macros`. `tests/ui/pass/*.rs` must compile *and run*: each one exercises a test-body shape against the mock `env` in `tests/ui/support/mock_env.rs` (fixed costs) and asserts which cost and limit the injected check reports, so a body shape that silently stops being checked fails there.
 


### PR DESCRIPTION
### Summary & Rationale
Consolidates duplicated Windows setup instructions across the repository by establishing `CONTRIBUTING.md#windows` as the single authoritative source and replacing the duplicated section in `docs/src/developer_guide.md` with a direct link.

Closes #229

### What Changed
- **Authoritative Guide**: Made `CONTRIBUTING.md#windows` the single canonical location for Windows setup instructions.
- **Link Replacement**: Replaced duplicated setup steps in `docs/src/developer_guide.md` with a direct link referencing `CONTRIBUTING.md#windows`.
- **Preserved Content**: Retained both **PowerShell** and **Git Bash** shell instructions, Visual C++ Build Tools requirement, `wasm32v1-none` target setup, and the permanent `[Environment]::SetEnvironmentVariable` PATH configuration snippet.
- **Changelog**: Added entry under `### Changed` in `CHANGELOG.md`.
- **Docs Cleanup**: Removed duplicated `amm-pool-contract` testing list block in `developer_guide.md`.

### Environment & Verification
- **Windows Version**: Microsoft Windows 11 Pro (Build `10.0.22621`)
- **Shells Verified**: Windows PowerShell `5.1.22621.3672` & Git Bash (`C:\Program Files\Git\bin\bash.exe`)
- **Tooling & Targets**: Verified Rust toolchain installation, `wasm32v1-none` target support, and PATH environment configuration.