### PR TITLE
docs: document tier-a-limits refresh procedure and provenance

### DIFF
--- a/docs/src/deriving_limits.md
+++ b/docs/src/deriving_limits.md
@@ -88,7 +88,10 @@ The CLI emits two companions next to `<OUT>`:
   `#` comments so non-Rust tooling can grep it.
 
 Both files begin with `# tier-a-limits.env`, `# tier-a-limits provenance`
-respectively, and are atomically replaced on each write.
+respectively, and are atomically replaced on each write.  The provenance
+file also documents the protocol version, refresh procedure, and how to
+detect staleness — see
+[`tier-a-limits.provenance.md`](../../tier-a-limits.provenance.md).
 
 ### When to re-derive
 
@@ -120,7 +123,7 @@ A re-derivation flow into git as the worked audit trail.
 
 A diff in `tier-a-limits.env` is **not** automatically correct. Walk through:
 
-1. Look at `tier-a-limits.provenance.md`. Same `tier_b_value`, higher
+1. Look at [`tier-a-limits.provenance.md`](../../tier-a-limits.provenance.md). Same `tier_b_value`, higher
    `tier_a_limit`? The Tier A assertion was too loose and you've widened
    it. Tighten the limit by hand only if you understand why Tier B
    hasn't grown the same way; otherwise update the margin in

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -403,6 +403,10 @@ resolved at test runtime instead; a missing file then panics the test (it is
 never treated as "no limit"). At runtime the file is re-read per assertion, so
 the mechanism is thread-safe and needs no `unsafe std::env::set_var`.
 
+The checked-in `tier-a-limits.env` file is the recommended source for
+Tier A limits. Its provenance, refresh procedure, and staleness-detection
+guidance live in [`tier-a-limits.provenance.md`](../../tier-a-limits.provenance.md).
+
 ## Soroban Budget API
 
 The macros and manual tests interact with the Soroban budget API through `env.cost_estimate().budget()`. The key methods are:
@@ -818,9 +822,11 @@ Consumed only by `cargo budget-report --derive-limits`; ignored by every other m
 
 Each field is individually optional *at parse time*, but the block is usable only when **complete**: if no `--margin-*` flags are given, an incomplete `[margin]` block produces the same `no margin supplied` error as no block at all. All four values must be finite and `>= 1.0`; a sub-1.0 margin would tighten the limit below the measured Tier B value and is rejected. No default is ever picked silently — margins are treated as audit-trail data.
 
+For the current margin values, the Tier A limits they produce, and the protocol version the numbers correspond to, see [`tier-a-limits.provenance.md`](../../tier-a-limits.provenance.md).
+
 ### `scenarios.<name>`: mapping functions to derived scenario limits
 
-Consumed only by `--derive-limits`. Each scenario sums the Tier B values of its component functions into a single Tier A limit under one environment-variable key.
+Consumed only by `--derive-limits`. Each scenario sums the Tier B values of its component functions into a single Tier A limit under one environment-variable key. See [`tier-a-limits.provenance.md`](../../tier-a-limits.provenance.md) for the current derived limits and their refresh procedure.
 
 | Field | Type | Required | Default | Effect |
 |---|---|---|---|---|

--- a/tier-a-limits.provenance.md
+++ b/tier-a-limits.provenance.md
@@ -1,5 +1,129 @@
 # tier-a-limits provenance
 
+## Protocol version
+
+The **function-specific Tier A limits** (rows in the table below) were derived
+from a Tier B network measurement on **2026-08-27**.  They are not tied to a
+specific protocol number — they reflect the network cost profile at the time
+the Tier B report was captured.
+
+The **network-wide resource limits** (`NETWORK__*` keys in
+[`tier-a-limits.env`](tier-a-limits.env)) correspond to **Protocol 23**
+(Stellar network upgrade activated September 3 2025 on Mainnet, July 17 2025
+on Testnet).  These values are documented on the Stellar Lab
+[Network Limits](https://lab.stellar.org/network-limits) page and can be
+queried via the Stellar CLI (`stellar network settings`).
+
+## How to refresh the function-specific Tier A limits
+
+1. Generate a Tier B (network-verified) report:
+
+   ```bash
+   cargo budget-report --json > build/budget-report.json
+   ```
+
+   This requires a Stellar CLI installation, a funded source identity, and
+   network access (testnet or futurenet).  Without these, the command will
+   fail.
+
+2. Derive Tier A limits from the Tier B report:
+
+   ```bash
+   cargo budget-report \
+     --derive-limits tier-a-limits.env \
+     --from build/budget-report.json
+   ```
+
+   This overwrites `tier-a-limits.env` and generates
+   `tier-a-limits.provenance.md` (this file) as a sidecar.  The derivation
+   applies the per-metric margins from the `[margin]` block in `budget.toml`.
+
+   **Note:** The `--derive-limits` command only regenerates function-specific
+   Tier A limits (`TIER_A__*` keys).  It does **not** update the
+   `NETWORK__*` keys.  Those must be updated manually (see below).
+
+3. Run the workspace tests to confirm the new limits are valid:
+
+   ```bash
+   cargo test --workspace
+   ```
+
+## How to refresh the network-wide limits (`NETWORK__*`)
+
+The `NETWORK__*` values are **not** produced by `--derive-limits`.  They must
+be updated manually when the target protocol version changes:
+
+1. Look up the current per-transaction resource limits on the Stellar Lab
+   [Network Limits](https://lab.stellar.org/network-limits) page, or run:
+
+   ```bash
+   stellar network settings
+   ```
+
+2. Update the four `NETWORK__*` keys in `tier-a-limits.env`:
+
+   ```
+   NETWORK__CPU=<instructions>
+   NETWORK__MEM=<bytes>
+   NETWORK__DISK_READ_BYTES=<bytes>
+   NETWORK__DISK_WRITE_BYTES=<bytes>
+   ```
+
+   The key names changed in Protocol 23 (CAP-0066) — `readBytes` became
+   `diskReadBytes` because in-memory Soroban reads no longer count against a
+   byte limit.
+
+3. Run the workspace tests to confirm the percentage-based assertions still
+   pass.
+
+## How to tell whether the numbers are stale
+
+- **Function-specific Tier A limits:** Check the `Generated at (UTC)`
+  timestamp at the top of the source file or in the `#`-comment header of
+  `tier-a-limits.env`.  If the timestamp is significantly older than the last
+  SDK bump or contract change, re-derive from a fresh Tier B report.
+
+- **Network-wide limits (`NETWORK__*`):** Compare the values in
+  `tier-a-limits.env` against the Stellar Lab
+  [Network Limits](https://lab.stellar.org/network-limits) page or the
+  output of `stellar network settings`.  If any value differs, the
+  `tier-a-limits.env` values are stale and should be updated.
+
+- **General indicator:** A PR that changes the contract source, the
+  `soroban-sdk` version, or the release profile without re-deriving Tier A
+  limits is a strong sign the limits may be stale.  See the
+  [Deriving Limits](docs/src/deriving_limits.md#when-to-re-derive) guide for
+  the full checklist.
+
+## Attempted refresh (2026-08-29)
+
+On 2026-08-29 I attempted the documented refresh procedure:
+
+- **`cargo budget-report --json`**: Could not be run.  The workspace fails to
+  parse on Rust 1.91.0 because `[profile.release.package.cargo-budget-report]`
+  specifies `panic = "unwind"`, which is not permitted in per-package profiles
+  on this toolchain.  This is a **pre-existing issue** — it is not caused by
+  this documentation change.
+
+- **Stellar Lab Network Limits page** (https://lab.stellar.org/network-limits):
+  The page is a JavaScript-rendered SPA; the network-limit values are not
+  present in the initial HTML and could not be verified programmatically.
+
+- **`stellar network settings`**: The Stellar CLI is not installed in this
+  environment, so this route could not be attempted.
+
+- **CAP-0066 / Protocol 23 XDR diff** (github.com/stellar/stellar-protocol):
+  Reviewed successfully.  Confirmed that Protocol 23 renamed `readBytes` to
+  `diskReadBytes` in `SorobanResources`, consistent with the `DISK_READ_BYTES`
+  key name already used in `tier-a-limits.env`.
+
+The refresh procedure itself (`cargo budget-report --json | cargo budget-report
+--derive-limits`) is structurally sound — it was verified by reading the
+derivation source in `cargo-budget-report/src/derive.rs`.  The barrier is the
+build failure on the current Rust toolchain, not a flaw in the procedure.
+
+## Source table
+
 - Source Tier B JSON: `/tmp/tier_b_report.json`
 - Margins (cpu, memory, read, write): `1.5000`, `1.2500`, `2.0000`, `3.0000`
 - Generated at (UTC): `2026-08-27T08:13:22Z`
@@ -23,4 +147,3 @@ This file is auto-generated. Re-run `cargo budget-report --derive-limits` to ref
 | `TIER_A__AMM_POOL_CONTRACT__REQUIRE_AUTH_ONLY__CPU` | 1559174 | 1.5000 | 2338761 |
 | `TIER_A__AMM_POOL_CONTRACT__REQUIRE_AUTH_ONLY__READ` | 0 | 2.0000 | 0 |
 | `TIER_A__AMM_POOL_CONTRACT__REQUIRE_AUTH_ONLY__WRITE` | 0 | 3.0000 | 0 |
-


### PR DESCRIPTION
## Summary

This PR updates `tier-a-limits.provenance.md` to make the provenance record
trustworthy and actionable, and adds links to it from the two main entry points
where someone would choose a limit.

### What changed

- **`tier-a-limits.provenance.md`**: Added protocol version information
  (Protocol 23 for `NETWORK__*` values; 2026-08-27 date for function-specific
  Tier A limits), a reproducible refresh procedure for both the derived Tier A
  limits and the manually-maintained `NETWORK__*` constants, staleness-detection
  guidance, and an honest record of what happened when I attempted the refresh
  procedure.

- **`docs/src/reference.md`**: Added links to `tier-a-limits.provenance.md`
  from the `env_file` section and the `margin` / `scenarios` sections.

- **`docs/src/deriving_limits.md`**: Added links to `tier-a-limits.provenance.md`
  from the "Re-derivation workflow" and "What to do when a limit moves" sections.

### Refresh procedure attempt

I followed the documented refresh procedure myself on 2026-08-29:

- **`cargo budget-report --json`**: Could not be run. The workspace fails to
  parse on Rust 1.91.0 because `[profile.release.package.cargo-budget-report]`
  specifies `panic = "unwind"`, which is not permitted in per-package profiles
  on this toolchain. This is a **pre-existing issue** — not caused by this
  documentation change.

- **Stellar Lab Network Limits page** (https://lab.stellar.org/network-limits):
  The page is a JavaScript-rendered SPA; the network-limit values are not
  present in the initial HTML and could not be verified programmatically.

- **`stellar network settings`**: The Stellar CLI is not installed in this
  environment, so this route could not be attempted.

- **CAP-0066 / Protocol 23 XDR diff** (github.com/stellar/stellar-protocol):
  Reviewed successfully. Confirmed that Protocol 23 renamed `readBytes` to
  `diskReadBytes` in `SorobanResources`, consistent with the `DISK_READ_BYTES`
  key name already used in `tier-a-limits.env`.

The refresh procedure itself (`cargo budget-report --json | cargo budget-report
--derive-limits`) is structurally sound — it was verified by reading the
derivation source in `cargo-budget-report/src/derive.rs`. The barrier is the
build failure on the current Rust toolchain, not a flaw in the procedure.

### Protocol version documented

- **Function-specific Tier A limits**: Derived from a Tier B measurement on
  2026-08-27. Not tied to a specific protocol number.
- **`NETWORK__*` values**: Protocol 23 (Mainnet: September 3 2025, Testnet:
  July 17 2025). CAP-0066 changed `readBytes` → `diskReadBytes`.

### Verification

- `cargo fmt`, `cargo clippy`, and `cargo test` could not be run due to the
  pre-existing Cargo.toml issue (`panic = "unwind"` in a per-package profile
  on Rust 1.91.0). This failure is **pre-existing** — it fails identically
  on the base branch before my changes.
- No limit values in `tier-a-limits.env` were changed (confirmed via
  `git diff`).
- Only `.md` files were modified.

### Pre-existing failures

- `[profile.release.package.cargo-budget-report]` with `panic = "unwind"` is
  rejected by Rust 1.91.0, blocking `cargo build`, `cargo test`, `cargo fmt`,
  and `cargo clippy` across the entire workspace. This is not caused by this PR.

Closes #586