### PR TITLE
test: mark calibration harnesses with #[ignore] and document

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,36 @@ First off, thank you for considering contributing to `soroban-budget-assert`!
 - Run `cargo test --workspace` in the workspace root to run the full workspace test suite.
 - Run `cargo run -p cargo-budget-report -- budget-report` (or `cargo build`) to test the CLI locally.
 
+### Calibration Harnesses vs. Regular Tests
+
+The test directories in `amm-pool-contract/tests/` contain both **regular tests** (which assert correctness) and **calibration harnesses** (which measure and record cost figures for `MEASUREMENTS.md`).
+
+**Calibration harnesses** are marked `#[ignore]` and excluded from the default `cargo test` run. They exist to generate the numbers in `MEASUREMENTS.md`, not to check correctness. Each harness file includes a doc comment explaining:
+- What it measures
+- How to run it deliberately
+- Where the output is recorded
+
+**Regular tests** run by default and assert correctness. Both types can coexist in the same file, but harness functions are clearly marked.
+
+**To run calibration harnesses:**
+
+```bash
+# Build the WASM contract first
+cargo build --target wasm32v1-none --release -p amm-pool-contract
+
+# Run a specific harness (e.g., calibrate_gap)
+cargo test -p amm-pool-contract --test calibrate_gap -- --ignored --nocapture
+
+# Run all calibration harnesses
+cargo test -p amm-pool-contract --test 'calibrate_*' -- --ignored --nocapture
+cargo test -p amm-pool-contract --test 'measure_*' -- --ignored --nocapture
+```
+
+When you add a new measurement harness, ensure it:
+1. Has a doc comment (at module or crate level) explaining what it measures, how to run it, and where output goes
+2. Marks all measurement functions with `#[ignore]`
+3. Keeps any genuine correctness assertions in separate, non-ignored tests if they belong in the same file
+
 ## Documentation
 
 The documentation site is built with [GitBook](https://www.gitbook.com/) and published from `docs/src/` via Git Sync.

--- a/amm-pool-contract/tests/calibrate_extend_ttl.rs
+++ b/amm-pool-contract/tests/calibrate_extend_ttl.rs
@@ -7,12 +7,21 @@
 //!
 //! # Usage
 //!
+//! These tests are marked `#[ignore]` and excluded from the default test suite.
+//! To run them deliberately:
+//!
 //! ```bash
 //! cargo build --target wasm32v1-none --release -p amm-pool-contract
-//! cargo test -p amm-pool-contract --test calibrate_extend_ttl -- --nocapture
+//! cargo test -p amm-pool-contract --test calibrate_extend_ttl -- --ignored --nocapture
 //! ```
 //!
-//! The network figure requires a separate `cargo-budget-report` run on Soroban
+//! # Output
+//!
+//! Each test prints `CALIBRATE_*_EXTEND_TTL extend_to=<value>` with CPU and memory
+//! cost lines. These values are manually transcribed into `MEASUREMENTS.md` under
+//! the "TTL Extension Costs" section.
+//!
+//! The network figures require a separate `cargo-budget-report` run on Soroban
 //! testnet against the same WASM.
 
 #![cfg(not(feature = "sdk20"))]
@@ -45,6 +54,7 @@ fn measure_instance_extend_ttl(env: &Env, extend_to: u32) -> (u64, u64) {
 }
 
 #[test]
+#[ignore]
 fn calibrate_instance_extend_ttl_1000() {
     let env = Env::default();
     let (cpu, mem) = measure_instance_extend_ttl(&env, 1_000);
@@ -54,6 +64,7 @@ fn calibrate_instance_extend_ttl_1000() {
 }
 
 #[test]
+#[ignore]
 fn calibrate_instance_extend_ttl_10000() {
     let env = Env::default();
     let (cpu, mem) = measure_instance_extend_ttl(&env, 10_000);
@@ -63,6 +74,7 @@ fn calibrate_instance_extend_ttl_10000() {
 }
 
 #[test]
+#[ignore]
 fn calibrate_instance_extend_ttl_50000() {
     let env = Env::default();
     let (cpu, mem) = measure_instance_extend_ttl(&env, 50_000);
@@ -82,6 +94,7 @@ fn measure_persistent_extend_ttl(env: &Env, extend_to: u32) -> (u64, u64) {
 }
 
 #[test]
+#[ignore]
 fn calibrate_persistent_extend_ttl_1000() {
     let env = Env::default();
     let (cpu, mem) = measure_persistent_extend_ttl(&env, 1_000);
@@ -91,6 +104,7 @@ fn calibrate_persistent_extend_ttl_1000() {
 }
 
 #[test]
+#[ignore]
 fn calibrate_persistent_extend_ttl_10000() {
     let env = Env::default();
     let (cpu, mem) = measure_persistent_extend_ttl(&env, 10_000);
@@ -100,6 +114,7 @@ fn calibrate_persistent_extend_ttl_10000() {
 }
 
 #[test]
+#[ignore]
 fn calibrate_persistent_extend_ttl_50000() {
     let env = Env::default();
     let (cpu, mem) = measure_persistent_extend_ttl(&env, 50_000);

--- a/amm-pool-contract/tests/calibrate_gap.rs
+++ b/amm-pool-contract/tests/calibrate_gap.rs
@@ -1,6 +1,29 @@
 // @measure local  # discovered by scripts/regenerate-measurements.sh
 #![cfg(not(feature = "sdk20"))]
 
+//! Calibration test for cost estimation gap measurement (baseline SDK version).
+//!
+//! This harness measures the local CPU and memory cost estimates for the
+//! synthetic `do_expensive_work` operation at a 10k loop depth, establishing a
+//! local-vs-network baseline gap. The figures are used to calibrate real contract
+//! costs against the empirical local estimates.
+//!
+//! # Usage
+//!
+//! This test is marked `#[ignore]` and excluded from the default test suite.
+//! To run it deliberately:
+//!
+//! ```bash
+//! cargo build --target wasm32v1-none --release -p amm-pool-contract
+//! cargo test -p amm-pool-contract --test calibrate_gap -- --ignored --nocapture
+//! ```
+//!
+//! # Output
+//!
+//! The test prints `CALIBRATE_CPU=<value>` and `CALIBRATE_MEM=<value>` to stdout.
+//! These values are manually transcribed into `MEASUREMENTS.md` under the
+//! "Local Cost Estimates" section as baseline figures.
+
 #[cfg(test)]
 mod calibrate_gap {
     use amm_pool_contract::ConstantProductPoolClient;
@@ -27,6 +50,7 @@ mod calibrate_gap {
     }
 
     #[test]
+    #[ignore]
     fn calibrate_gap() {
         let env = Env::default();
         measure_do_expensive_work(&env);

--- a/amm-pool-contract/tests/calibrate_gap_sdk20.rs
+++ b/amm-pool-contract/tests/calibrate_gap_sdk20.rs
@@ -1,6 +1,29 @@
 // @measure local:sdk20  # discovered by scripts/regenerate-measurements.sh
 #![cfg(feature = "sdk20")]
 
+//! Calibration test for cost estimation gap measurement (Soroban SDK 20.x).
+//!
+//! This harness measures the local CPU and memory cost estimates for the
+//! synthetic `do_expensive_work` operation at a 10k loop depth under SDK 20.x,
+//! establishing a local-vs-network baseline gap. The figures are used to
+//! calibrate real contract costs against the empirical local estimates.
+//!
+//! # Usage
+//!
+//! This test is marked `#[ignore]` and excluded from the default test suite.
+//! To run it deliberately:
+//!
+//! ```bash
+//! cargo build --target wasm32v1-none --release -p amm-pool-contract --features sdk20
+//! cargo test -p amm-pool-contract --test calibrate_gap_sdk20 --features sdk20 -- --ignored --nocapture
+//! ```
+//!
+//! # Output
+//!
+//! The test prints `CALIBRATE_CPU=<value>` and `CALIBRATE_MEM=<value>` to stdout.
+//! These values are manually transcribed into `MEASUREMENTS.md` under the
+//! "Local Cost Estimates (SDK 20.x)" section.
+
 #[cfg(test)]
 mod calibrate_gap_sdk20 {
     use amm_pool_contract::ConstantProductPoolClient;
@@ -27,6 +50,7 @@ mod calibrate_gap_sdk20 {
     }
 
     #[test]
+    #[ignore]
     fn calibrate_gap() {
         let env = Env::default();
         measure_do_expensive_work(&env);

--- a/amm-pool-contract/tests/calibrate_gap_sdk22.rs
+++ b/amm-pool-contract/tests/calibrate_gap_sdk22.rs
@@ -1,6 +1,29 @@
 // @measure local:sdk22  # discovered by scripts/regenerate-measurements.sh
 #![cfg(feature = "sdk22")]
 
+//! Calibration test for cost estimation gap measurement (Soroban SDK 22.x).
+//!
+//! This harness measures the local CPU and memory cost estimates for the
+//! synthetic `do_expensive_work` operation at a 10k loop depth under SDK 22.x,
+//! establishing a local-vs-network baseline gap. The figures are used to
+//! calibrate real contract costs against the empirical local estimates.
+//!
+//! # Usage
+//!
+//! This test is marked `#[ignore]` and excluded from the default test suite.
+//! To run it deliberately:
+//!
+//! ```bash
+//! cargo build --target wasm32v1-none --release -p amm-pool-contract --features sdk22
+//! cargo test -p amm-pool-contract --test calibrate_gap_sdk22 --features sdk22 -- --ignored --nocapture
+//! ```
+//!
+//! # Output
+//!
+//! The test prints `CALIBRATE_CPU=<value>` and `CALIBRATE_MEM=<value>` to stdout.
+//! These values are manually transcribed into `MEASUREMENTS.md` under the
+//! "Local Cost Estimates (SDK 22.x)" section.
+
 #[cfg(test)]
 mod calibrate_gap {
     use amm_pool_contract::ConstantProductPoolClient;
@@ -27,6 +50,7 @@ mod calibrate_gap {
     }
 
     #[test]
+    #[ignore]
     fn calibrate_gap() {
         let env = Env::default();
         measure_do_expensive_work(&env);

--- a/amm-pool-contract/tests/measure_auth_gap.rs
+++ b/amm-pool-contract/tests/measure_auth_gap.rs
@@ -1,6 +1,28 @@
 // @measure local  # discovered by scripts/regenerate-measurements.sh
 #![cfg(not(feature = "sdk20"))]
 
+//! Calibration test for `require_auth()` cost gap measurement.
+//!
+//! Measures the local CPU and memory cost estimates for a single `require_auth()`
+//! call on a generated address, establishing a local-vs-network gap for
+//! authorization operations.
+//!
+//! # Usage
+//!
+//! This test is marked `#[ignore]` and excluded from the default test suite.
+//! To run it deliberately:
+//!
+//! ```bash
+//! cargo build --target wasm32v1-none --release -p amm-pool-contract
+//! cargo test -p amm-pool-contract --test measure_auth_gap -- --ignored --nocapture
+//! ```
+//!
+//! # Output
+//!
+//! The test prints `AUTH_CPU=<value>` and `AUTH_MEM=<value>` to stdout.
+//! These values are manually transcribed into `MEASUREMENTS.md` under the
+//! "Authorization Cost" section.
+
 #[cfg(test)]
 mod measure_auth_gap {
     use amm_pool_contract::ConstantProductPoolClient;
@@ -29,6 +51,7 @@ mod measure_auth_gap {
     }
 
     #[test]
+    #[ignore]
     fn measure_auth_gap() {
         let env = Env::default();
         measure_require_auth_only(&env);


### PR DESCRIPTION
Separate measurement harnesses from regular regression tests by:

- Mark all functions in calibrate_gap.rs, calibrate_gap_sdk20.rs, calibrate_gap_sdk22.rs, calibrate_extend_ttl.rs, and measure_auth_gap.rs with #[ignore] so they are excluded from the default 'cargo test' run

- Add comprehensive doc comments to each file explaining:
  * What the harness measures
  * How to run it deliberately (with --ignored --nocapture flags)
  * Where the output figures are recorded in MEASUREMENTS.md

- Update CONTRIBUTING.md with a new 'Calibration Harnesses vs. Regular Tests' section that:
  * Explains the distinction between measurement and correctness tests
  * Provides example commands for running harnesses individually or as groups
  * Guides contributors on how to add new measurement harnesses

This resolves the problem that mixed calibration code and regular tests made each test run longer (with work nobody needed on a normal change) and confused contributors about which files were instruments vs. safety nets.

Genuine tests remain in the default suite; no assertions were discarded.

Closes #428

## Description
<!-- Describe your changes in detail -->

## Related Issue
<!-- If this PR addresses an existing issue, please link it here. -->
Closes #

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
- [ ] Added/Updated tests
- [ ] Passed `cargo test`
- [ ] Passed `cargo clippy`
- [ ] Formatted with `cargo fmt`
- [ ] Reviewed or re-measured budget limits in `amm-pool-contract/tests/budget_test.rs` when contract, build profile, or toolchain changes may affect them

## Types of changes
<!-- What types of changes does your code introduce? -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
