### PR TITLE
docs: document all public budget macros in reference and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,3 +308,4 @@ cargo run -p cargo-budget-report --bin generate-manpage -- cargo-budget-report.1
 ```
 
 This writes the rendered `cargo-budget-report` man page to the chosen output path.
+// Stellar Wave #494

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -1108,3 +1108,175 @@ CPU failure is reported. The macro supports the same attribute forms as
 `budget_cpu_lt` and `budget_mem_lt`: integer literal, `env = "VAR"`,
 `env_file = "PATH"`, `config = "key"`, and `baseline = <expr>`.
 
+
+### `#[budget_write_bytes_lt(N)]` — write-bytes assertion
+
+Asserts that the ledger write bytes used by `env` are strictly less than `N`.
+Write bytes represent the total bytes written to ledger storage during contract
+execution. This macro measures the local `memory_bytes_cost` as a proxy, which
+correlates with storage serialization overhead even though the exact on-network
+write-bytes figure is only available via RPC simulation.
+
+**Static limit:**
+
+```rust
+use budget_macros::budget_write_bytes_lt;
+
+#[test]
+#[budget_write_bytes_lt(4096)]
+fn test_write_bytes_budget() {
+    let env = Env::default();
+    // ... register contract as WASM, invoke client ...
+}
+```
+
+**Dynamic limit from environment variable:**
+
+```rust
+#[test]
+#[budget_write_bytes_lt(env = "MAX_WRITE_BYTES")]
+fn test_write_bytes_with_env() {
+    std::env::set_var("MAX_WRITE_BYTES", "4096");
+    let env = Env::default();
+    // ...
+}
+```
+
+**Limit from `.env` file:**
+
+```rust
+#[test]
+#[budget_write_bytes_lt(
+    env_file = "../tier-a-limits.env",
+    env = "TIER_A__AMM_POOL_CONTRACT__DEPOSIT__WRITE"
+)]
+fn test_write_bytes_from_file() {
+    let env = Env::default();
+    // ...
+}
+```
+
+**Config-driven limit from `budget.json`:**
+
+```rust
+#[test]
+#[budget_write_bytes_lt(config = "write_bytes")]
+fn test_write_bytes_from_config() {
+    let env = Env::default();
+    // ...
+}
+```
+
+**Baseline subtraction** — `baseline = <expr>` subtracts a fixed floor from the
+measurement before comparison, so the *marginal* write-bytes cost is asserted.
+The subtraction saturates at 0.
+
+```rust
+#[test]
+#[budget_write_bytes_lt(4096, baseline = instantiation_floor_write_bytes())]
+fn test_marginal_write_bytes() {
+    let env = Env::default();
+    // ...
+}
+```
+
+Failure message format:
+```
+Write bytes cost (memory proxy) {actual} exceeded limit {N} - local estimate, underestimates real network cost
+```
+and with a baseline:
+```
+Write bytes cost (memory proxy) {marginal} exceeded limit {N} (marginal: {measured} measured - {baseline} baseline) - local estimate, underestimates real network cost
+```
+
+### `#[budget_read_bytes_lt(N)]` — read-bytes assertion
+
+Asserts that the ledger read bytes used by `env` are strictly less than `N`.
+Read bytes represent the total bytes read from ledger storage during contract
+execution. This macro measures the local `memory_bytes_cost` as a proxy, which
+correlates with storage access overhead even though the exact on-network
+read-bytes figure is only available via RPC simulation.
+
+**Static limit:**
+
+```rust
+use budget_macros::budget_read_bytes_lt;
+
+#[test]
+#[budget_read_bytes_lt(4096)]
+fn test_read_bytes_budget() {
+    let env = Env::default();
+    // ...
+}
+```
+
+**Dynamic limit:**
+
+```rust
+#[test]
+#[budget_read_bytes_lt(env = "MAX_READ_BYTES")]
+fn test_read_bytes_with_env_limit() {
+    let env = Env::default();
+    // ...
+}
+```
+
+**Limit from a `.env` file:**
+
+```rust
+#[test]
+#[budget_read_bytes_lt(
+    env_file = "../tier-a-limits.env",
+    env = "TIER_A__AMM_POOL_CONTRACT__DEPOSIT__READ"
+)]
+fn test_read_bytes_from_file() {
+    let env = Env::default();
+    // ...
+}
+```
+
+**Config-driven limit:**
+
+```rust
+#[test]
+#[budget_read_bytes_lt(config = "read_bytes")]
+fn test_read_bytes_from_config() {
+    let env = Env::default();
+    // ...
+}
+```
+
+**Baseline subtraction** — same semantics as `budget_write_bytes_lt`:
+
+```rust
+#[test]
+#[budget_read_bytes_lt(4096, baseline = instantiation_floor_read_bytes())]
+fn test_marginal_read_bytes() {
+    let env = Env::default();
+    // ...
+}
+```
+
+Failure message format:
+```
+Read bytes cost (memory proxy) {actual} exceeded limit {N} - local estimate, underestimates real network cost
+```
+and with a baseline:
+```
+Read bytes cost (memory proxy) {marginal} exceeded limit {N} (marginal: {measured} measured - {baseline} baseline) - local estimate, underestimates real network cost
+```
+
+### Complete macro quick-reference
+
+| Macro | Measures | Failure prefix | Baseline support |
+|---|---|---|---|
+| `#[budget_cpu_lt(N)]` | CPU instructions | `CPU instruction cost` | Yes |
+| `#[budget_mem_lt(N)]` | Memory bytes | `Memory bytes cost` | Yes |
+| `#[budget_write_bytes_lt(N)]` | Write bytes (memory proxy) | `Write bytes cost (memory proxy)` | Yes |
+| `#[budget_read_bytes_lt(N)]` | Read bytes (memory proxy) | `Read bytes cost (memory proxy)` | Yes |
+| `#[budget_lt(N)]` | Both CPU + memory | `CPU instruction cost` or `Memory bytes cost` | Yes |
+| `#[budget_scaling(...)]` | CPU growth model | `{fn} scaling: {model}` | N/A |
+
+All macros accept the same limit sources: integer literal, `env = "VAR"`,
+`env_file = "PATH", env = "VAR"`, or `config = "key"`. The `baseline` parameter
+is available on all macros except `budget_scaling`.

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -1032,3 +1032,79 @@ Effects of this file:
 - `withdraw` has an entry but no `*_limit` fields, so its metrics are reported and it participates in `--check`'s fail-on-simulation-error rule, but no metric is enforced.
 - If `amm-pool-contract` were renamed tomorrow, every section above would keep working unchanged except `[scenarios.full_workflow]`, whose `package` value must match the annotation used by Tier A tests.
 - If `initialize` had been misspelled (e.g. `[functions.initialise]`), nothing would error and nothing would fail: the orphaned entry would be ignored, `initialize` would run unconfigured with no arguments, and none of its metrics would be enforced — the only symptom is missing rows in a later report.
+
+### `#[budget_lt(N)]`
+
+Generic budget assertion — asserts that **both** CPU instruction cost **and**
+memory bytes cost are strictly less than `N`. This macro is a convenience
+shorthand when you want a single ceiling covering both metrics.
+
+**Static limit:**
+
+```rust
+use budget_macros::budget_lt;
+
+#[test]
+#[budget_lt(1_000_000)]
+fn test_generic_budget() {
+    let env = Env::default();
+    // ... contract invocation ...
+}
+```
+
+**Dynamic limit from environment variable:**
+
+```rust
+#[test]
+#[budget_lt(env = "GENERIC_BUDGET_LIMIT")]
+fn test_generic_with_env() {
+    std::env::set_var("GENERIC_BUDGET_LIMIT", "1000000");
+    let env = Env::default();
+    // ...
+}
+```
+
+**Limit from `.env` file:**
+
+```rust
+#[test]
+#[budget_lt(env_file = "../tier-a-limits.env", env = "TIER_A__GENERIC__LIMIT")]
+fn test_generic_from_file() {
+    let env = Env::default();
+    // ...
+}
+```
+
+**Config-driven limit:**
+
+```rust
+#[test]
+#[budget_lt(config = "generic_budget")]
+fn test_generic_from_config() {
+    let env = Env::default();
+    // ...
+}
+```
+
+**Baseline subtraction:**
+
+```rust
+#[test]
+#[budget_lt(1_000_000, baseline = instantiation_floor())]
+fn test_generic_marginal() {
+    let env = Env::default();
+    // ...
+}
+```
+
+Failure message format:
+```
+CPU instruction cost {cpu} exceeded limit {N}
+Memory bytes cost {mem} exceeded limit {N}
+```
+
+The first check that fails triggers the panic — if both are over, only the
+CPU failure is reported. The macro supports the same attribute forms as
+`budget_cpu_lt` and `budget_mem_lt`: integer literal, `env = "VAR"`,
+`env_file = "PATH"`, `config = "key"`, and `baseline = <expr>`.
+


### PR DESCRIPTION
Documents all five public budget macros in the tool reference and README.

Closes #494